### PR TITLE
Documentation - proper rendering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ If the estimator does not support `partial_fit`, a warning will be shown saying 
 - numpy (>=1.16)
 - ray
 - scikit-learn (>=0.23)
-- cloudpickle
 
 #### User Installation
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If the estimator does not support `partial_fit`, a warning will be shown saying 
 
 #### User Installation
 
-`pip install tune-sklearn`
+`pip install tune-sklearn ray[tune]`
 
 ## Examples
 #### TuneGridSearchCV

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ tabulate
 ray
 bayesian-optimization
 parameterized
-cloudpickle
 pytest
 xgboost
 torch

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(
     name="tune_sklearn",
     packages=["tune_sklearn"],
+    version="0.0.3",
     author="Michael Chau/Anthony Yu",
     description="An experimental scikit-learn API on Tune",
     long_description="An API enabling faster scikit-learn training using Tune "

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -21,7 +21,7 @@ class _Trainable(Trainable):
 
     """
 
-    def setup(self, config):
+    def _setup(self, config):
         """Sets up Trainable attributes during initialization.
 
         Also sets up parameters for the sklearn estimator passed in.
@@ -56,7 +56,7 @@ class _Trainable(Trainable):
         else:
             self.estimator.set_params(**self.estimator_config)
 
-    def step(self):
+    def _train(self):
         """Trains one iteration of the model called when ``tune.run`` is called.
 
         Different routines are run depending on if the ``early_stopping``
@@ -159,7 +159,7 @@ class _Trainable(Trainable):
 
             return ret
 
-    def save_checkpoint(self, checkpoint_dir):
+    def _save(self, checkpoint_dir):
         """Creates a checkpoint in ``checkpoint_dir``, creating a pickle file.
 
         Args:
@@ -181,8 +181,8 @@ class _Trainable(Trainable):
                               .format(self.estimator))
         return path
 
-    def load_checkpoint(self, checkpoint):
-        """Loads a checkpoint created from `save_checkpoint`.
+    def _restore(self, checkpoint):
+        """Loads a checkpoint created from `save`.
 
         Args:
             checkpoint (str): file path to pickled checkpoint file.

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -9,7 +9,7 @@ from sklearn.utils.metaestimators import _safe_split
 import numpy as np
 import os
 from pickle import PicklingError
-import cloudpickle as cpickle
+import ray.cloudpickle as cpickle
 import warnings
 
 
@@ -21,7 +21,7 @@ class _Trainable(Trainable):
 
     """
 
-    def _setup(self, config):
+    def setup(self, config):
         """Sets up Trainable attributes during initialization.
 
         Also sets up parameters for the sklearn estimator passed in.
@@ -56,7 +56,7 @@ class _Trainable(Trainable):
         else:
             self.estimator.set_params(**self.estimator_config)
 
-    def _train(self):
+    def step(self):
         """Trains one iteration of the model called when ``tune.run`` is called.
 
         Different routines are run depending on if the ``early_stopping``
@@ -159,7 +159,7 @@ class _Trainable(Trainable):
 
             return ret
 
-    def _save(self, checkpoint_dir):
+    def save_checkpoint(self, checkpoint_dir):
         """Creates a checkpoint in ``checkpoint_dir``, creating a pickle file.
 
         Args:
@@ -181,8 +181,8 @@ class _Trainable(Trainable):
                               .format(self.estimator))
         return path
 
-    def _restore(self, checkpoint):
-        """Loads a checkpoint created from `_save`.
+    def load_checkpoint(self, checkpoint):
+        """Loads a checkpoint created from `save_checkpoint`.
 
         Args:
             checkpoint (str): file path to pickled checkpoint file.

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -34,8 +34,7 @@ class TuneBaseSearchCV(BaseEstimator):
 
     defined_schedulers = [
         "PopulationBasedTraining", "AsyncHyperBandScheduler",
-        "HyperBandScheduler", "HyperBandForBOHB", "MedianStoppingRule",
-        "ASHAScheduler"
+        "HyperBandScheduler", "MedianStoppingRule", "ASHAScheduler"
     ]
 
     @property
@@ -207,8 +206,10 @@ class TuneBaseSearchCV(BaseEstimator):
 
         self.estimator = estimator
 
-        if early_stopping is not None and self._can_early_stop():
+        if early_stopping and self._can_early_stop():
             self.max_iters = max_iters
+            if early_stopping is True:
+                early_stopping = "AsyncHyperBandScheduler"
             if isinstance(early_stopping, str):
                 if early_stopping in TuneBaseSearchCV.defined_schedulers:
                     if early_stopping == "PopulationBasedTraining":
@@ -219,9 +220,6 @@ class TuneBaseSearchCV(BaseEstimator):
                             metric="average_test_score")
                     elif early_stopping == "HyperBandScheduler":
                         self.early_stopping = HyperBandScheduler(
-                            metric="average_test_score")
-                    elif early_stopping == "HyperBandForBOHB":
-                        self.early_stopping = HyperBandForBOHB(
                             metric="average_test_score")
                     elif early_stopping == "MedianStoppingRule":
                         self.early_stopping = MedianStoppingRule(

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -22,7 +22,7 @@ from sklearn.exceptions import NotFittedError
 import ray
 from ray.tune.schedulers import (
     PopulationBasedTraining, AsyncHyperBandScheduler, HyperBandScheduler,
-    HyperBandForBOHB, MedianStoppingRule, TrialScheduler, ASHAScheduler)
+    MedianStoppingRule, TrialScheduler, ASHAScheduler)
 import numpy as np
 from numpy.ma import MaskedArray
 import warnings

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -235,7 +235,8 @@ class TuneBaseSearchCV(BaseEstimator):
                 self.early_stopping = early_stopping
                 self.early_stopping.metric = "average_test_score"
             else:
-                raise TypeError("Scheduler must be a str or tune scheduler")
+                raise TypeError("`early_stopping` must be a str, boolean, "
+                                "or tune scheduler")
         else:
             warnings.warn("Early stopping is not enabled. "
                           "To enable early stopping, pass in a supported "

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -257,23 +257,23 @@ class TuneBaseSearchCV(BaseEstimator):
         self.use_gpu = use_gpu
 
     def fit(self, X, y=None, groups=None, **fit_params):
-        """Run fit with all sets of parameters. ``tune.run`` is used to perform
-        the fit procedure, which is put in a helper function ``_tune_run``.
+        """Run fit with all sets of parameters.
+
+        ``tune.run`` is used to perform the fit procedure.
 
         Args:
             X (:obj:`array-like` (shape = [n_samples, n_features])):
                 Training vector, where n_samples is the number of samples and
                 n_features is the number of features.
-            y (:obj:`array-like` (shape = [n_samples] or
-                [n_samples, n_output]), optional):
-                Target relative to X for classification or regression;
-                None for unsupervised learning.
+            y (:obj:`array-like`): Shape of array expected to be [n_samples]
+                or [n_samples, n_output]). Target relative to X for
+                classification or regression; None for unsupervised learning.
             groups (:obj:`array-like` (shape (n_samples,)), optional):
                 Group labels for the samples used while splitting the dataset
                 into train/test set. Only used in conjunction with a "Group"
                 `cv` instance (e.g., `GroupKFold`).
-            **fit_params (:obj:`dict` of str):
-                Parameters passed to the ``fit`` method of the estimator.
+            **fit_params (:obj:`dict` of str): Parameters passed to
+                the ``fit`` method of the estimator.
 
         Returns:
             :obj:`TuneBaseSearchCV` child instance, after fitting.
@@ -341,12 +341,12 @@ class TuneBaseSearchCV(BaseEstimator):
         """Compute the score(s) of an estimator on a given test set.
 
         Args:
-            X (:obj:`array-like` (shape = [n_samples, n_features])):
-                Input data, where n_samples is the number of samples and
+            X (:obj:`array-like` (shape = [n_samples, n_features])): Input
+                data, where n_samples is the number of samples and
                 n_features is the number of features.
-            y (:obj:`array-like` (shape = [n_samples] or
-                [n_samples, n_output]), optional):
-                Target relative to X for classification or regression;
+            y (:obj:`array-like`): Shape of array is expected to be
+                [n_samples] or [n_samples, n_output]). Target relative to X
+                for classification or regression. You can also pass in
                 None for unsupervised learning.
 
         Returns:

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -53,9 +53,13 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             using all processors. Defaults to None.
         cv (int, `cross-validation generator` or `iterable`): Determines the
             cross-validation splitting strategy. Possible inputs for cv are:
+
             - None, to use the default 5-fold cross validation,
+
             - integer, to specify the number of folds in a `(Stratified)KFold`,
+
             - An iterable yielding (train, test) splits as arrays of indices.
+
             For integer/None inputs, if the estimator is a classifier and ``y``
             is either binary or multiclass, :class:`StratifiedKFold` is used.
             In all other cases, :class:`KFold` is used. Defaults to None.
@@ -92,7 +96,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             computationally expensive and is not strictly required to select
             the parameters that yield the best generalization performance.
         max_iters (int): Indicates the maximum number of epochs to run for each
-            hyperparameter configuration sampled (specified by ``n_iter``).
+            hyperparameter configuration sampled.
             This parameter is used for early stopping. Defaults to 10.
     """
 

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -24,110 +24,76 @@ class TuneGridSearchCV(TuneBaseSearchCV):
     by cross-validated grid-search over a parameter grid.
 
     Args:
-        estimator (:obj:`estimator`): This is assumed to implement the
-                scikit-learn estimator interface.
-                Either estimator needs to provide a ``score`` function,
-                or ``scoring`` must be passed.
-
-        param_grid (:obj:`dict` or :obj:`list` of :obj:`dict`):
-            Dictionary with parameters names (string) as keys and lists of
+        estimator (`estimator`): Object that implements the
+            scikit-learn estimator interface. Either estimator needs to
+            provide a ``score`` function, or ``scoring`` must be passed.
+        param_grid (`dict` or `list` of `dict`): Dictionary with parameters
+            names (string) as keys and lists of
             parameter settings to try as values, or a list of such
             dictionaries, in which case the grids spanned by each dictionary
             in the list are explored. This enables searching over any sequence
             of parameter settings.
-
-        early_stopping (str or :obj:`TrialScheduler`, optional):
-            Scheduler for executing fit with early stopping.
-
+        early_stopping (str or `TrialScheduler`, optional): Scheduler for
+            executing fit with early stopping.
             Refer to ray.tune.schedulers for all options. If a string is given,
             a scheduler will be created with default parameters. To specify
             parameters of the scheduler, pass in a scheduler object instead of
             a string. The scheduler will be used if the estimator supports
             partial fitting to stop fitting to a hyperparameter configuration
-            if it performs poorly.
-
-            If None, early stopping will not be used. This is the default.
-
-        scoring (str, :obj:`callable`, :obj:`list`, :obj:`tuple`, :obj:`dict`
-            or None):
-            A single string (see :ref:`scoring_parameter`) or a callable
-            (see :ref:`scoring`) to evaluate the predictions on the test set.
-
+            if it performs poorly. If None, early stopping will not be used.
+        scoring (str, `callable`, `list`, `tuple`, `dict` or None): A single
+            string or a callable to evaluate the predictions on the test set.
             For evaluating multiple metrics, either give a list of (unique)
             strings or a dict with names as keys and callables as values.
-
             NOTE that when using custom scorers, each scorer should return a
             single value. Metric functions returning a list/array of values can
             be wrapped into multiple scorers that return one value each.
-
             If None, the estimator's score method is used. Defaults to None.
-
-        n_jobs (int):
-            Number of jobs to run in parallel. None or -1 means using all
-            processors. Defaults to None.
-
-        cv (int, :obj`cross-validation generator` or :obj:`iterable`):
-            Determines the cross-validation splitting strategy.
-
-            Possible inputs for cv are:
+        n_jobs (int): Number of jobs to run in parallel. None or -1 means
+            using all processors. Defaults to None.
+        cv (int, `cross-validation generator` or `iterable`): Determines the
+            cross-validation splitting strategy. Possible inputs for cv are:
             - None, to use the default 5-fold cross validation,
             - integer, to specify the number of folds in a `(Stratified)KFold`,
             - An iterable yielding (train, test) splits as arrays of indices.
-
             For integer/None inputs, if the estimator is a classifier and ``y``
             is either binary or multiclass, :class:`StratifiedKFold` is used.
             In all other cases, :class:`KFold` is used. Defaults to None.
-
-        refit (bool, str, or :obj:`callable`):
+        refit (bool, str, or `callable`):
             Refit an estimator using the best found parameters on the whole
             dataset.
-
             For multiple metric evaluation, this needs to be a string denoting
             the scorer that would be used to find the best parameters for
             refitting the estimator at the end.
-
             The refitted estimator is made available at the ``best_estimator_``
             attribute and permits using ``predict`` directly on this
             ``GridSearchCV`` instance.
-
             Also for multiple metric evaluation, the attributes
             ``best_index_``, ``best_score_`` and ``best_params_`` will only be
             available if ``refit`` is set and all of them will be determined
             w.r.t this specific scorer. ``best_score_`` is not returned if
             refit is callable.
-
             See ``scoring`` parameter to know more about multiple metric
             evaluation.
-
             Defaults to True.
-
-        verbose (int):
-            Controls the verbosity: 0 = silent, 1 = only status updates,
-            2 = status and trial results. Defaults to 0.
-
-        error_score ('raise' or int or float):
-            Value to assign to the score if an error occurs in estimator
-            fitting. If set to 'raise', the error is raised. If a numeric value
+        verbose (int): Controls the verbosity: 0 = silent, 1 = only
+            status updates, 2 = status and trial results. Defaults to 0.
+        error_score ('raise' or int or float): Value to assign to the score
+            if an error occurs in estimator fitting. If set to 'raise',
+            the error is raised. If a numeric value
             is given, FitFailedWarning is raised. This parameter does not
             affect the refit step, which will always raise the error.
             Defaults to np.nan.
-
-        return_train_score (bool):
-            If ``False``, the ``cv_results_`` attribute will not include
-            training scores. Defaults to False.
-
+        return_train_score (bool): If ``False``, the ``cv_results_``
+            attribute will not include training scores. Defaults to False.
             Computing training scores is used to get insights on how different
             parameter settings impact the overfitting/underfitting trade-off.
-
             However computing the scores on the training set can be
             computationally expensive and is not strictly required to select
             the parameters that yield the best generalization performance.
-
-        max_iters (int):
-            Indicates the maximum number of epochs to run for each
+        max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_iter``).
             This parameter is used for early stopping. Defaults to 10.
-
     """
 
     def __init__(self,
@@ -166,7 +132,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         have been grid searched over.
 
         Args:
-            config (:obj:`dict`): dictionary to be filled in as the
+            config (`dict`): dictionary to be filled in as the
                 configuration for `tune.run`.
 
         """
@@ -197,7 +163,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                 are integers specifying the number of each resource to use.
 
         Returns:
-            analysis (:obj:`ExperimentAnalysis`): Object returned by
+            analysis (`ExperimentAnalysis`): Object returned by
                 `tune.run`.
 
         """

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -33,14 +33,19 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             dictionaries, in which case the grids spanned by each dictionary
             in the list are explored. This enables searching over any sequence
             of parameter settings.
-        early_stopping (str or `TrialScheduler`, optional): Scheduler for
-            executing fit with early stopping.
-            Refer to ray.tune.schedulers for all options. If a string is given,
-            a scheduler will be created with default parameters. To specify
-            parameters of the scheduler, pass in a scheduler object instead of
-            a string. The scheduler will be used if the estimator supports
-            partial fitting to stop fitting to a hyperparameter configuration
-            if it performs poorly. If None, early stopping will not be used.
+        early_stopping (bool, str or :class:`TrialScheduler`, optional): Option
+            to stop fitting to a hyperparameter configuration if it performs
+            poorly. Possible inputs are:
+
+            - If True, defaults to ASHAScheduler.
+            - A string corresponding to the name of a Tune Trial Scheduler
+              (i.e., "ASHAScheduler"). To specify parameters of the scheduler,
+              pass in a scheduler object instead of a string.
+            - Scheduler for executing fit with early stopping. Only a subset
+              of schedulers are currently supported. The scheduler will only be
+              used if the estimator supports partial fitting
+            - If None or False, early stopping will not be used.
+
         scoring (str, `callable`, `list`, `tuple`, `dict` or None): A single
             string or a callable to evaluate the predictions on the test set.
             For evaluating multiple metrics, either give a list of (unique)
@@ -55,9 +60,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             cross-validation splitting strategy. Possible inputs for cv are:
 
             - None, to use the default 5-fold cross validation,
-
             - integer, to specify the number of folds in a `(Stratified)KFold`,
-
             - An iterable yielding (train, test) splits as arrays of indices.
 
             For integer/None inputs, if the estimator is a classifier and ``y``

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -59,15 +59,19 @@ class TuneSearchCV(TuneBaseSearchCV):
             parameter names (strings) and values are tuples.
             Represents search space over parameters of
             the provided estimator.
-        early_stopping (str or `TrialScheduler`, optional): Scheduler for
-            executing fit with early stopping.
-            Refer to ray.tune.schedulers for all options. If a string is given,
-            a scheduler will be created with default parameters. To specify
-            parameters of the scheduler, pass in a scheduler object instead of
-            a string. The scheduler will be used if the estimator supports
-            partial fitting to stop fitting to a hyperparameter configuration
-            if it performs poorly.
-            If None, early stopping will not be used. This is the default.
+        early_stopping (bool, str or :class:`TrialScheduler`, optional): Option
+            to stop fitting to a hyperparameter configuration if it performs
+            poorly. Possible inputs are:
+
+            - If True, defaults to ASHAScheduler.
+            - A string corresponding to the name of a Tune Trial Scheduler
+              (i.e., "ASHAScheduler"). To specify parameters of the scheduler,
+              pass in a scheduler object instead of a string.
+            - Scheduler for executing fit with early stopping. Only a subset
+              of schedulers are currently supported. The scheduler will only be
+              used if the estimator supports partial fitting
+            - If None or False, early stopping will not be used.
+
         n_iter (int): Number of parameter settings that are sampled.
             n_iter trades off runtime vs quality of the solution.
             Defaults to 10.
@@ -101,13 +105,9 @@ class TuneSearchCV(TuneBaseSearchCV):
             the cross-validation splitting strategy.
             Possible inputs for cv are:
 
-                - None, to use the default 5-fold cross validation,
-
-                - integer, to specify the number of folds in a
-                `(Stratified)KFold`,
-
-                - An iterable yielding (train, test) splits as
-                arrays of indices.
+            - None, to use the default 5-fold cross validation,
+            - integer, to specify the number of folds in a `(Stratified)KFold`,
+            - An iterable yielding (train, test) splits as arrays of indices.
 
             For integer/None inputs, if the estimator is a classifier and ``y``
             is either binary or multiclass, :class:`StratifiedKFold` is used.

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -35,159 +35,122 @@ class TuneSearchCV(TuneBaseSearchCV):
     given by n_iter.
 
     Args:
-        estimator (:obj:`estimator`): This is assumed to implement the
-            scikit-learn estimator interface.
-            Either estimator needs to provide a ``score`` function,
-            or ``scoring`` must be passed.
-
-        param_distributions (:obj:`dict`):
-            Serves as the ``param_distributions`` parameter in scikit-learn's
+        estimator (`estimator`): This is assumed to implement the
+            scikit-learn estimator interface. Either estimator needs to
+            provide a ``score`` function, or ``scoring`` must be passed.
+        param_distributions (`dict`): Serves as the ``param_distributions``
+            parameter in scikit-learn's
             ``RandomizedSearchCV`` or as the ``search_space`` parameter in
             ``BayesSearchCV``.
-
             For randomized search: dictionary with parameters names (string)
             as keys and distributions or lists of parameter settings to try
             for randomized search.
-
             Distributions must provide a rvs  method for sampling (such as
             those from scipy.stats.distributions).
-
             If a list is given, it is sampled uniformly. If a list of dicts is
             given, first a dict is sampled uniformly, and then a parameter is
             sampled using that dict as above.
-
             For Bayesian search: it is one of these cases:
 
-            1. dictionary, where keys are parameter names (strings) and values
-            are skopt.space.Dimension instances (Real, Integer or Categorical)
-            or any other valid value that defines skopt dimension (see
-            skopt.Optimizer docs). Represents search space over parameters of
-            the provided estimator.
+                1. dictionary, where keys are parameter names (strings) and values
+                are skopt.space.Dimension instances (Real, Integer or Categorical)
+                or any other valid value that defines skopt dimension (see
+                skopt.Optimizer docs). Represents search space over parameters of
+                the provided estimator.
 
-            2. list of dictionaries: a list of dictionaries, where every
-            dictionary fits the description given in case 1 above. If a list of
-            dictionary objects is given, then the search is performed
-            sequentially for every parameter space with maximum number of
-            evaluations set to self.n_iter.
+                2. list of dictionaries: a list of dictionaries, where every
+                dictionary fits the description given in case 1 above. If a list of
+                dictionary objects is given, then the search is performed
+                sequentially for every parameter space with maximum number of
+                evaluations set to self.n_iter.
 
-            3. list of (dict, int > 0): an extension of case 2 above, where
-            first element of every tuple is a dictionary representing some
-            search subspace, similarly as in case 2, and second element is a
-            number of iterations that will be spent optimizing over this
-            subspace.
-
-        early_stopping (str or :obj:`TrialScheduler`, optional):
-            Scheduler for executing fit with early stopping.
-
+                3. list of (dict, int > 0): an extension of case 2 above, where
+                first element of every tuple is a dictionary representing some
+                search subspace, similarly as in case 2, and second element is a
+                number of iterations that will be spent optimizing over this
+                subspace.
+        early_stopping (str or `TrialScheduler`, optional): Scheduler for
+            executing fit with early stopping.
             Refer to ray.tune.schedulers for all options. If a string is given,
             a scheduler will be created with default parameters. To specify
             parameters of the scheduler, pass in a scheduler object instead of
             a string. The scheduler will be used if the estimator supports
             partial fitting to stop fitting to a hyperparameter configuration
             if it performs poorly.
-
             If None, early stopping will not be used. This is the default.
-
-        n_iter (int):
-            Number of parameter settings that are sampled. n_iter trades
-            off runtime vs quality of the solution. Defaults to 10.
-
-        scoring (str, :obj:`callable`, :obj:`list`, :obj:`tuple`, :obj:`dict`
-            or None):
-            A single string (see :ref:`scoring_parameter`) or a callable
-            (see :ref:`scoring`) to evaluate the predictions on the test set.
-
+        n_iter (int): Number of parameter settings that are sampled.
+            n_iter trades off runtime vs quality of the solution.
+            Defaults to 10.
+        scoring (str, `callable`, `list`, `tuple`, `dict`
+            or None): A single string (see Scikit-Learn documentation
+            on `scoring_parameter`) or a callable
+            to evaluate the predictions on the test set.
             For evaluating multiple metrics, either give a list of (unique)
             strings or a dict with names as keys and callables as values.
-
             NOTE that when using custom scorers, each scorer should return a
             single value. Metric functions returning a list/array of values
             can be wrapped into multiple scorers that return one value each.
-
             If None, the estimator's score method is used. Defaults to None.
-
-        n_jobs (int):
-            Number of jobs to run in parallel. None or -1 means using all
-            processors. Defaults to None.
-
-        refit (bool, str, or :obj:`callable`):
-            Refit an estimator using the best found parameters on the whole
-            dataset.
-
+        n_jobs (int): Number of jobs to run in parallel. None or -1 means
+            using all processors. Defaults to None.
+        refit (bool, str, or `callable`): Refit an estimator using the
+            best found parameters on the whole dataset.
             For multiple metric evaluation, this needs to be a string denoting
             the scorer that would be used to find the best parameters for
             refitting the estimator at the end.
-
             The refitted estimator is made available at the ``best_estimator_``
             attribute and permits using ``predict`` directly on this
             ``GridSearchCV`` instance.
-
             Also for multiple metric evaluation, the attributes
             ``best_index_``, ``best_score_`` and ``best_params_`` will only be
             available if ``refit`` is set and all of them will be determined
             w.r.t this specific scorer. ``best_score_`` is not returned if
-            refit is callable.
-
-            See ``scoring`` parameter to know more about multiple metric
-            evaluation.
-
-            Defaults to True.
-
-        cv (int, :obj`cross-validation generator` or :obj:`iterable`):
-            Determines the cross-validation splitting strategy.
-
+            refit is callable. See ``scoring`` parameter to know more about
+            multiple metric evaluation. Defaults to True.
+        cv (int, `cross-validation generator` or `iterable`): Determines
+            the cross-validation splitting strategy.
             Possible inputs for cv are:
-            - None, to use the default 5-fold cross validation,
-            - integer, to specify the number of folds in a `(Stratified)KFold`,
-            - An iterable yielding (train, test) splits as arrays of indices.
+
+                - None, to use the default 5-fold cross validation,
+
+                - integer, to specify the number of folds in a `(Stratified)KFold`,
+
+                - An iterable yielding (train, test) splits as arrays of indices.
 
             For integer/None inputs, if the estimator is a classifier and ``y``
             is either binary or multiclass, :class:`StratifiedKFold` is used.
             In all other cases, :class:`KFold` is used. Defaults to None.
-
-        verbose (int):
-            Controls the verbosity: 0 = silent, 1 = only status updates,
-            2 = status and trial results. Defaults to 0.
-
-        random_state (int or :obj:`RandomState`):
-            Pseudo random number generator state used for random uniform
+        verbose (int): Controls the verbosity: 0 = silent, 1 = only status
+            updates, 2 = status and trial results. Defaults to 0.
+        random_state (int or `RandomState`): Pseudo random number generator
+            state used for random uniform
             sampling from lists of possible values instead of scipy.stats
             distributions.
-
             If int, random_state is the seed used by the random number
             generator;
             If RandomState instance, random_state is the random number
             generator;
             If None, the random number generator is the RandomState instance
             used by np.random. Defaults to None.
-
             Ignored when doing Bayesian search.
-
-        error_score ('raise' or int or float):
-            Value to assign to the score if an error occurs in estimator
+        error_score ('raise' or int or float): Value to assign to the score if
+            an error occurs in estimator
             fitting. If set to 'raise', the error is raised. If a numeric value
             is given, FitFailedWarning is raised. This parameter does not
             affect the refit step, which will always raise the error.
             Defaults to np.nan.
-
-        return_train_score (bool):
-            If ``False``, the ``cv_results_`` attribute will not include
-            training scores. Defaults to False.
-
+        return_train_score (bool): If ``False``, the ``cv_results_``
+            attribute will not include training scores. Defaults to False.
             Computing training scores is used to get insights on how different
             parameter settings impact the overfitting/underfitting trade-off.
-
             However computing the scores on the training set can be
             computationally expensive and is not strictly required to select
             the parameters that yield the best generalization performance.
-
-        max_iters (int):
-            Indicates the maximum number of epochs to run for each
+        max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_iter``).
             This parameter is used for early stopping. Defaults to 10.
-
-        search_optimization ("random" or "bayesian"):
-            If "random", uses randomized search over the
+        search_optimization ("random" or "bayesian"): If "random", uses
+            randomized search over the
             ``param_distributions``. If "bayesian", uses Bayesian
             optimization to search for hyperparameters.
 
@@ -273,7 +236,7 @@ class TuneSearchCV(TuneBaseSearchCV):
         by ``rvs``.
 
         Args:
-            config (:obj:`dict`): dictionary to be filled in as the
+            config (`dict`): dictionary to be filled in as the
                 configuration for `tune.run`.
 
         """
@@ -318,7 +281,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                 are integers specifying the number of each resource to use.
 
         Returns:
-            analysis (:obj:`ExperimentAnalysis`): Object returned by
+            analysis (`ExperimentAnalysis`): Object returned by
                 `tune.run`.
 
         """

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -38,8 +38,8 @@ class TuneSearchCV(TuneBaseSearchCV):
         estimator (`estimator`): This is assumed to implement the
             scikit-learn estimator interface. Either estimator needs to
             provide a ``score`` function, or ``scoring`` must be passed.
-        param_distributions (`dict`): Serves as the ``param_distributions``
-            parameter in scikit-learn's
+        param_distributions (`dict` or `list`): Serves as the
+            ``param_distributions`` parameter in scikit-learn's
             ``RandomizedSearchCV`` or as the ``search_space`` parameter in
             ``BayesSearchCV``.
             For randomized search: dictionary with parameters names (string)
@@ -50,25 +50,15 @@ class TuneSearchCV(TuneBaseSearchCV):
             If a list is given, it is sampled uniformly. If a list of dicts is
             given, first a dict is sampled uniformly, and then a parameter is
             sampled using that dict as above.
-            For Bayesian search: it is one of these cases:
-
-                1. dictionary, where keys are parameter names (strings) and values
-                are skopt.space.Dimension instances (Real, Integer or Categorical)
-                or any other valid value that defines skopt dimension (see
-                skopt.Optimizer docs). Represents search space over parameters of
-                the provided estimator.
-
-                2. list of dictionaries: a list of dictionaries, where every
-                dictionary fits the description given in case 1 above. If a list of
-                dictionary objects is given, then the search is performed
-                sequentially for every parameter space with maximum number of
-                evaluations set to self.n_iter.
-
-                3. list of (dict, int > 0): an extension of case 2 above, where
-                first element of every tuple is a dictionary representing some
-                search subspace, similarly as in case 2, and second element is a
-                number of iterations that will be spent optimizing over this
-                subspace.
+            For Bayesian search:
+            If an object is passed in for ``search_optimization``,
+            ``param_distributions`` is ignored because the user specifies
+            the search space.
+            If the string "bayesian" is passed in, ``param_distributions``
+            is a dictionary where keys are
+            parameter names (strings) and values are tuples.
+            Represents search space over parameters of
+            the provided estimator.
         early_stopping (str or `TrialScheduler`, optional): Scheduler for
             executing fit with early stopping.
             Refer to ray.tune.schedulers for all options. If a string is given,
@@ -113,9 +103,11 @@ class TuneSearchCV(TuneBaseSearchCV):
 
                 - None, to use the default 5-fold cross validation,
 
-                - integer, to specify the number of folds in a `(Stratified)KFold`,
+                - integer, to specify the number of folds in a
+                `(Stratified)KFold`,
 
-                - An iterable yielding (train, test) splits as arrays of indices.
+                - An iterable yielding (train, test) splits as
+                arrays of indices.
 
             For integer/None inputs, if the estimator is a classifier and ``y``
             is either binary or multiclass, :class:`StratifiedKFold` is used.
@@ -149,10 +141,10 @@ class TuneSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_iter``).
             This parameter is used for early stopping. Defaults to 10.
-        search_optimization ("random" or "bayesian"): If "random", uses
-            randomized search over the
-            ``param_distributions``. If "bayesian", uses Bayesian
-            optimization to search for hyperparameters.
+        search_optimization ("random", "bayesian", or :obj:`BayesOptSearch`):
+            If "random", uses randomized search over the
+            ``param_distributions``. If "bayesian" or ``BayesOptSearch``,
+            uses Bayesian optimization to search for hyperparameters.
 
     """
 


### PR DESCRIPTION
This PR consists of two main changes to make the docstrings renderable on docs.ray.io - 

1. remove :ref: to Scikit-learn specific concepts
2. Proper white-spacing/indentations (readthedocs is sensitive to newlines, so I removed as many of them as I could.)