### PR TITLE
switch to skopt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - python3 -m unittest test_randomizedsearch.py
   - python3 -m unittest test_gridsearch.py
   - cd ../examples
-  - for f in *.py; do python "$f"; done
+  - for f in *.py; do python3 "$f"; done
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,7 @@ script:
   - python3 -m unittest test_randomizedsearch.py
   - python3 -m unittest test_gridsearch.py
   - cd ../examples
-  - python3 random_forest.py
-  - python3 sgd.py
-  - python3 torch_nn.py
-  - python3 lgbm.py
-  - python3 xgbclassifier.py
-  - python3 keras_example.py
-  - python3 sklearn_pipeline.py
-  - python3 bayesian_sgd.py
+  - for f in *.py; do python "$f"; done
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ print("Sklearn Accuracy:", accuracy)
 
 #### TuneSearchCV
 
-`TuneSearchCV` uses randomized search over the distribution by default, but can do Bayesian search as well by specifying the `search_optimization` parameter as shown here. You need to run `pip install scikit-optimize` for this to work. More details in [Tune Documentation](https://docs.ray.io/en/latest/tune-searchalg.html#bayesopt-search).
+`TuneSearchCV` uses randomized search over the distribution by default, but can do Bayesian search as well by specifying the `search_optimization` parameter as shown here. You need to run `pip install scikit-optimize` for this to work. More details in [Tune Documentation] (https://docs.ray.io/en/master/tune/api_docs/suggestion.html?highlight=bayesian#scikit-optimize-tune-suggest-skopt-skoptsearch).
 
 ```python
 from tune_sklearn import TuneSearchCV

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ print("Sklearn Accuracy:", accuracy)
 
 #### TuneSearchCV
 
-`TuneSearchCV` uses randomized search over the distribution by default, but can do Bayesian search as well by specifying the `search_optimization` parameter as shown here. You need to run `pip install bayesian-optimization` for this to work. More details in [Tune Documentation](https://docs.ray.io/en/latest/tune-searchalg.html#bayesopt-search).
+`TuneSearchCV` uses randomized search over the distribution by default, but can do Bayesian search as well by specifying the `search_optimization` parameter as shown here. You need to run `pip install scikit-optimize` for this to work. More details in [Tune Documentation](https://docs.ray.io/en/latest/tune-searchalg.html#bayesopt-search).
 
 ```python
 from tune_sklearn import TuneSearchCV

--- a/examples/discrete_bayesian.py
+++ b/examples/discrete_bayesian.py
@@ -1,0 +1,28 @@
+from tune_sklearn import TuneSearchCV
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from ray.tune.suggest.bayesopt import BayesOptSearch
+
+digits = datasets.load_digits()
+X = digits.data
+y = digits.target
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+
+space = {'n_estimators': (100,200),
+        'min_samples_split': (2, 10),
+        'min_samples_leaf': (1, 5)}
+
+tune_search = TuneSearchCV(
+    RandomForestClassifier(),
+    space,
+    search_optimization="bayesian",
+    n_iter=3,
+    max_iters=10,
+)
+tune_search.fit(X_train, y_train)
+
+print(tune_search.cv_results_)
+print(tune_search.best_params_)

--- a/examples/discrete_bayesian.py
+++ b/examples/discrete_bayesian.py
@@ -1,9 +1,8 @@
 from tune_sklearn import TuneSearchCV
 from sklearn import datasets
 from sklearn.model_selection import train_test_split
-import numpy as np
 from sklearn.ensemble import RandomForestClassifier
-from ray.tune.suggest.bayesopt import BayesOptSearch
+from skopt.space.space import Real
 
 digits = datasets.load_digits()
 X = digits.data
@@ -11,9 +10,11 @@ y = digits.target
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
-space = {'n_estimators': (100,200),
-        'min_samples_split': (2, 10),
-        'min_samples_leaf': (1, 5)}
+space = {
+    "n_estimators": (100, 200),
+    "min_weight_fraction_leaf": Real(0.0, 0.5),
+    "min_samples_leaf": (1, 5)
+}
 
 tune_search = TuneSearchCV(
     RandomForestClassifier(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scikit-learn
 pandas
 tabulate
 ray
-bayesian-optimization
+scikit-optimize
 parameterized
 pytest
 xgboost

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -76,6 +76,7 @@ class TuneSearchCV(TuneBaseSearchCV):
               of schedulers are currently supported. The scheduler will only be
               used if the estimator supports partial fitting
             - If None or False, early stopping will not be used.
+
         n_iter (int): Number of parameter settings that are sampled.
             n_iter trades off runtime vs quality of the solution.
             Defaults to 10.

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -62,8 +62,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             - as a list of categories (for Categorical dimensions), or
             - an instance of a Dimension object (Real, Integer or Categorical).
 
-            https://scikit-optimize.github.io/stable/modules/generated/
-            skopt.Optimizer.html#skopt.Optimizer
+            https://scikit-optimize.github.io/stable/modules/
+            classes.html#module-skopt.space.space
         early_stopping (bool, str or :class:`TrialScheduler`, optional): Option
             to stop fitting to a hyperparameter configuration if it performs
             poorly. Possible inputs are:

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -74,6 +74,9 @@ class TuneSearchCV(TuneBaseSearchCV):
               used if the estimator supports partial fitting
             - If None or False, early stopping will not be used.
 
+            https://scikit-optimize.github.io/stable/modules/generated/
+            skopt.Optimizer.html#skopt.Optimizer
+
         n_iter (int): Number of parameter settings that are sampled.
             n_iter trades off runtime vs quality of the solution.
             Defaults to 10.
@@ -146,7 +149,9 @@ class TuneSearchCV(TuneBaseSearchCV):
         search_optimization ("random" or "bayesian"):
             If "random", uses randomized search over the
             ``param_distributions``. If "bayesian", uses
-            Bayesian optimization to search for hyperparameters.
+            Bayesian optimization from scikit-optimize
+            (https://scikit-optimize.github.io/stable/index.html)
+            to search for hyperparameters.
 
     """
 

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -61,6 +61,9 @@ class TuneSearchCV(TuneBaseSearchCV):
               (for Real dimensions),
             - as a list of categories (for Categorical dimensions), or
             - an instance of a Dimension object (Real, Integer or Categorical).
+
+            https://scikit-optimize.github.io/stable/modules/generated/
+            skopt.Optimizer.html#skopt.Optimizer
         early_stopping (bool, str or :class:`TrialScheduler`, optional): Option
             to stop fitting to a hyperparameter configuration if it performs
             poorly. Possible inputs are:
@@ -73,10 +76,6 @@ class TuneSearchCV(TuneBaseSearchCV):
               of schedulers are currently supported. The scheduler will only be
               used if the estimator supports partial fitting
             - If None or False, early stopping will not be used.
-
-            https://scikit-optimize.github.io/stable/modules/generated/
-            skopt.Optimizer.html#skopt.Optimizer
-
         n_iter (int): Number of parameter settings that are sampled.
             n_iter trades off runtime vs quality of the solution.
             Defaults to 10.


### PR DESCRIPTION
Change bayesian search to SkOpt backend to allow for searching over discrete integers.