### PR TITLE
Warm start for ensembles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ notifications:
 
 install:
   - pip3 install -U -q pip
-  - pip3 install -U -q scikit-optimize hyperopt hpbandster ConfigSpace scipy
+  - pip3 install -U -q scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses
   - pip3 install -q -r requirements-test.txt
   - pip3 install --upgrade -q keras
   - pip3 install -U -q scikit-learn pytest

--- a/examples/bohb_example.py
+++ b/examples/bohb_example.py
@@ -28,3 +28,4 @@ bohb_tune_search = TuneSearchCV(
 )
 
 bohb_tune_search.fit(X_train, y_train)
+print(bohb_tune_search.best_params_)

--- a/examples/bohb_example.py
+++ b/examples/bohb_example.py
@@ -7,8 +7,8 @@ from sklearn.linear_model import SGDClassifier
 
 # Set training and validation sets
 X, y = make_classification(
-    n_samples=11000,
-    n_features=1000,
+    n_samples=5000,
+    n_features=200,
     n_informative=50,
     n_redundant=0,
     n_classes=10,

--- a/examples/warm_start_ensemble.py
+++ b/examples/warm_start_ensemble.py
@@ -1,0 +1,37 @@
+"""
+An example training a LogisticRegression model, performing grid search
+using TuneGridSearchCV.
+
+This example uses early stopping to further improve runtimes
+by eliminating worse hyperparameter choices early based off
+of its average test score from cross validation. Usually
+this will require the estimator to have `partial_fit`, but
+we use sklearn's `warm_start` parameter to do this here.
+We fit the estimator for one epoch, then `warm_start`
+to pick up from where we left off, continuing until the
+trial is early stopped or `max_iters` is reached.
+"""
+
+from tune_sklearn import TuneGridSearchCV
+from sklearn.model_selection import train_test_split
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+import numpy as np
+
+x, y = load_iris(return_X_y=True)
+x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=.2)
+
+clf = RandomForestClassifier()
+parameter_grid = {"min_samples_split": [2, 3, 4]}
+
+tune_search = TuneGridSearchCV(
+    clf,
+    parameter_grid,
+    early_stopping=True,
+    max_iters=20,
+)
+tune_search.fit(x_train, y_train)
+
+pred = tune_search.predict(x_test)
+accuracy = np.count_nonzero(np.array(pred) == np.array(y_test)) / len(pred)
+print(accuracy)

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -164,8 +164,9 @@ class RandomizedSearchTest(unittest.TestCase):
 
     def test_warm_start_detection(self):
         parameter_grid = {"alpha": Real(1e-4, 1e-1, 1)}
-        from sklearn.ensemble import VotingClassifier
-        clf = VotingClassifier(estimators=[('lr', clf1), ('rf', clf2), ('gnb', clf3)])
+        from sklearn.ensemble import VotingClassifier, RandomForestClassifier
+        clf = VotingClassifier(estimators=[(
+            "rf", RandomForestClassifier(n_estimators=50, random_state=0))])
         tune_search = TuneSearchCV(
             clf,
             parameter_grid,
@@ -197,8 +198,9 @@ class RandomizedSearchTest(unittest.TestCase):
 
     def test_warm_start_error(self):
         parameter_grid = {"alpha": Real(1e-4, 1e-1, 1)}
-        from sklearn.ensemble import RandomForestClassifier
-        clf = RandomForestClassifier(max_depth=2, random_state=0)
+        from sklearn.ensemble import VotingClassifier, RandomForestClassifier
+        clf = VotingClassifier(estimators=[(
+            "rf", RandomForestClassifier(n_estimators=50, random_state=0))])
         tune_search = TuneSearchCV(
             clf,
             parameter_grid,

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -165,7 +165,7 @@ class RandomizedSearchTest(unittest.TestCase):
     def test_warm_start_detection(self):
         parameter_grid = {"alpha": Real(1e-4, 1e-1, 1)}
         from sklearn.ensemble import VotingClassifier
-        clf = VotingClassifier()
+        clf = VotingClassifier(estimators=[('lr', clf1), ('rf', clf2), ('gnb', clf3)])
         tune_search = TuneSearchCV(
             clf,
             parameter_grid,

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -165,7 +165,7 @@ class RandomizedSearchTest(unittest.TestCase):
     def test_warm_start_detection(self):
         parameter_grid = {"alpha": Real(1e-4, 1e-1, 1)}
         from sklearn.ensemble import VotingClassifier
-        clf = VotingClassifier(max_depth=2, random_state=0)
+        clf = VotingClassifier()
         tune_search = TuneSearchCV(
             clf,
             parameter_grid,

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -164,8 +164,8 @@ class RandomizedSearchTest(unittest.TestCase):
 
     def test_warm_start_detection(self):
         parameter_grid = {"alpha": Real(1e-4, 1e-1, 1)}
-        from sklearn.ensemble import RandomForestClassifier
-        clf = RandomForestClassifier(max_depth=2, random_state=0)
+        from sklearn.ensemble import VotingClassifier
+        clf = VotingClassifier(max_depth=2, random_state=0)
         tune_search = TuneSearchCV(
             clf,
             parameter_grid,

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -13,8 +13,9 @@ import ray.cloudpickle as cpickle
 import warnings
 
 from tune_sklearn._detect_xgboost import is_xgboost_model
-from tune_sklearn.utils import (check_warm_start_iter, check_warm_start_ensemble,
-                                check_partial_fit, _aggregate_score_dicts)
+from tune_sklearn.utils import (check_warm_start_iter,
+                                check_warm_start_ensemble, check_partial_fit,
+                                _aggregate_score_dicts)
 
 
 class _Trainable(Trainable):
@@ -140,17 +141,12 @@ class _Trainable(Trainable):
         if self.early_stopping:
             for i, (train, test) in enumerate(self.cv.split(self.X, self.y)):
                 estimator = self.estimator_list[i]
-                X_train, y_train = _safe_split(estimator, self.X,
-                                               self.y, train)
+                X_train, y_train = _safe_split(estimator, self.X, self.y,
+                                               train)
                 X_test, y_test = _safe_split(
-                    estimator,
-                    self.X,
-                    self.y,
-                    test,
-                    train_indices=train)
+                    estimator, self.X, self.y, test, train_indices=train)
                 if self._can_partial_fit():
-                    estimator.partial_fit(X_train, y_train,
-                                                       np.unique(self.y))
+                    estimator.partial_fit(X_train, y_train, np.unique(self.y))
                 elif self._is_xgb():
                     estimator.fit(
                         X_train, y_train, xgb_model=self.saved_models[i])

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -423,9 +423,10 @@ class TuneBaseSearchCV(BaseEstimator):
                 mode="max",
                 scope="last").trial_id
             df = analysis.dataframe()
-            self.best_score = float(
-                df.loc[df["trial_id"] == best_finished_trial_id][
-                    "average_test_%s" % scoring_name])
+            best_val_loc = df.loc[df["trial_id"] == best_finished_trial_id]
+            best_val = best_val_loc["average_test_%s" % scoring_name]
+            # best_val is a pd.Series
+            self.best_score = float(best_val.to_list()[0])
 
             return self
 

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -30,7 +30,7 @@ import multiprocessing
 import os
 
 from tune_sklearn._detect_xgboost import is_xgboost_model
-from tune_sklearn.utils import (check_warm_start, check_warm_start_ensemble,
+from tune_sklearn.utils import (check_warm_start_iter, check_warm_start_ensemble,
                                 check_partial_fit, _check_multimetric_scoring)
 
 logger = logging.getLogger(__name__)
@@ -408,6 +408,10 @@ class TuneBaseSearchCV(BaseEstimator):
             if not check_partial_fit(
                     self.estimator) and check_warm_start_ensemble(
                         self.estimator):
+                logger.info("Warm start uses `n_estimators` to warm "
+                            "start, so this parameter can't be "
+                            "set when warm start early stopping. "
+                            "`n_estimators` defaults to `max_iters`.")
                 self.best_params["n_estimators"] = self.max_iters
             self.best_estimator_ = clone(self.estimator)
             self.best_estimator_.set_params(**self.best_params)
@@ -516,7 +520,7 @@ class TuneBaseSearchCV(BaseEstimator):
         """
 
         can_partial_fit = check_partial_fit(self.estimator)
-        can_warm_start = check_warm_start(self.estimator)
+        can_warm_start = check_warm_start_iter(self.estimator)
         can_warm_start_ensemble = check_warm_start_ensemble(self.estimator)
         is_gbm = is_xgboost_model(self.estimator)
 

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -30,8 +30,8 @@ import multiprocessing
 import os
 
 from tune_sklearn._detect_xgboost import is_xgboost_model
-from tune_sklearn.utils import (check_warm_start, check_partial_fit,
-                                _check_multimetric_scoring)
+from tune_sklearn.utils import (check_warm_start, check_warm_start_ensemble,
+                                check_partial_fit, _check_multimetric_scoring)
 
 logger = logging.getLogger(__name__)
 
@@ -405,6 +405,10 @@ class TuneBaseSearchCV(BaseEstimator):
                 mode="max",
                 scope="last")
             self.best_params = self._clean_config_dict(best_config)
+            if not check_partial_fit(
+                    self.estimator) and check_warm_start_ensemble(
+                        self.estimator):
+                self.best_params["n_estimators"] = self.max_iters
             self.best_estimator_ = clone(self.estimator)
             self.best_estimator_.set_params(**self.best_params)
             self.best_estimator_.fit(X, y, **fit_params)
@@ -513,9 +517,11 @@ class TuneBaseSearchCV(BaseEstimator):
 
         can_partial_fit = check_partial_fit(self.estimator)
         can_warm_start = check_warm_start(self.estimator)
+        can_warm_start_ensemble = check_warm_start_ensemble(self.estimator)
         is_gbm = is_xgboost_model(self.estimator)
 
-        return can_partial_fit or can_warm_start or is_gbm
+        return (can_partial_fit or can_warm_start or can_warm_start_ensemble
+                or is_gbm)
 
     def _fill_config_hyperparam(self, config):
         """Fill in the ``config`` dictionary with the hyperparameters.

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -259,7 +259,7 @@ class TuneBaseSearchCV(BaseEstimator):
                 raise ValueError("Early stopping is not supported because "
                                  "the estimator does not have `partial_fit`, "
                                  "does not support warm_start, or is a "
-                                 "tree or ensemble classifier. Set "
+                                 "tree classifier. Set "
                                  "`early_stopping=False`.")
         if not early_stopping and max_iters > 1:
             warnings.warn(

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -30,8 +30,9 @@ import multiprocessing
 import os
 
 from tune_sklearn._detect_xgboost import is_xgboost_model
-from tune_sklearn.utils import (check_warm_start_iter, check_warm_start_ensemble,
-                                check_partial_fit, _check_multimetric_scoring)
+from tune_sklearn.utils import (check_warm_start_iter,
+                                check_warm_start_ensemble, check_partial_fit,
+                                _check_multimetric_scoring)
 
 logger = logging.getLogger(__name__)
 

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -109,8 +109,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled.
             This parameter is used for early stopping. Defaults to 1.
-            When using warm start to early stop on ensembles, this will determine
-            `n_estimators` for the final refitted ensemble.`
+            When using warm start to early stop on ensembles, this will
+            determine `n_estimators` for the final refitted ensemble.`
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will use 1 gpu
             for `resources_per_trial`.

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -109,6 +109,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled.
             This parameter is used for early stopping. Defaults to 1.
+            When using warm start to early stop on ensembles, this will determine
+            `n_estimators` for the final refitted ensemble.`
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will use 1 gpu
             for `resources_per_trial`.

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -218,7 +218,9 @@ class TuneSearchCV(TuneBaseSearchCV):
             be stored. Defaults to "~/ray_results"
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_trials``).
-            This parameter is used for early stopping. Defaults to 10.
+            This parameter is used for early stopping. Defaults to 1.
+            When using warm start to early stop on ensembles, this will determine
+            `n_estimators` for the final refitted ensemble.`
         search_optimization ("random" or "bayesian" or "bohb" or "hyperopt"):
             Randomized search is invoked with ``search_optimization`` set to
             ``"random"`` and behaves like scikit-learn's

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -219,8 +219,8 @@ class TuneSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_trials``).
             This parameter is used for early stopping. Defaults to 1.
-            When using warm start to early stop on ensembles, this will determine
-            `n_estimators` for the final refitted ensemble.`
+            When using warm start to early stop on ensembles, this will
+            determine `n_estimators` for the final refitted ensemble.`
         search_optimization ("random" or "bayesian" or "bohb" or "hyperopt"):
             Randomized search is invoked with ``search_optimization`` set to
             ``"random"`` and behaves like scikit-learn's

--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -17,6 +17,14 @@ def check_warm_start(estimator):
             and is_not_tree_subclass)
 
 
+def check_warm_start_ensemble(estimator):
+    from sklearn.ensemble import BaseEnsemble
+    is_ensemble_subclass = issubclass(type(estimator), BaseEnsemble)
+
+    return (hasattr(estimator, "warm_start")
+            and hasattr(estimator, "n_estimators") and is_ensemble_subclass)
+
+
 def _aggregate_score_dicts(scores):
     """Aggregate the list of dict to dict of np ndarray
     The aggregated output of _fit_and_score will be a list of dict

--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -6,7 +6,7 @@ def check_partial_fit(estimator):
     return callable(getattr(estimator, "partial_fit", None))
 
 
-def check_warm_start(estimator):
+def check_warm_start_iter(estimator):
     from sklearn.tree import BaseDecisionTree
     from sklearn.ensemble import BaseEnsemble
     is_not_tree_subclass = not issubclass(type(estimator), BaseDecisionTree)


### PR DESCRIPTION
Add functionality to warm start ensembles estimators in sklearn. This relies on incrementing `n_estimators` one at a time to get the effect of fitting one estimator at a time in the ensemble. This unfortunately means the user can't cross validate the `n_estimators` parameter if they choose to early stop. 