### PR TITLE
Early stopping support for sklearn Pipelines

### DIFF
--- a/examples/sklearn_pipeline_early_stopping.py
+++ b/examples/sklearn_pipeline_early_stopping.py
@@ -47,7 +47,8 @@ print(grid.cv_results_)
 
 # warm start iter
 
-pipe = Pipeline([("reduce_dim", PCA()), ("classify", LogisticRegression(max_iter=1000))])
+pipe = Pipeline([("reduce_dim", PCA()), ("classify",
+                                         LogisticRegression(max_iter=1000))])
 
 param_grid = [
     {

--- a/examples/sklearn_pipeline_early_stopping.py
+++ b/examples/sklearn_pipeline_early_stopping.py
@@ -32,7 +32,7 @@ random = TuneSearchCV(
     search_optimization="random",
     early_stopping=True,
     max_iters=10,
-    pipeline_detection=True)
+    pipeline_auto_early_stop=True)
 random.fit(X, y)
 print(random.cv_results_)
 
@@ -41,13 +41,13 @@ grid = TuneGridSearchCV(
     param_grid=param_grid,
     early_stopping=True,
     max_iters=10,
-    pipeline_detection=True)
+    pipeline_auto_early_stop=True)
 grid.fit(X, y)
 print(grid.cv_results_)
 
 # warm start iter
 
-pipe = Pipeline([("reduce_dim", PCA()), ("classify", LogisticRegression())])
+pipe = Pipeline([("reduce_dim", PCA()), ("classify", LogisticRegression(max_iter=1000))])
 
 param_grid = [
     {
@@ -61,7 +61,7 @@ random = TuneSearchCV(
     search_optimization="random",
     early_stopping=True,
     max_iters=10,
-    pipeline_detection=True)
+    pipeline_auto_early_stop=True)
 random.fit(X, y)
 print(random.cv_results_)
 
@@ -82,6 +82,6 @@ random = TuneSearchCV(
     search_optimization="random",
     early_stopping=True,
     max_iters=10,
-    pipeline_detection=True)
+    pipeline_auto_early_stop=True)
 random.fit(X, y)
 print(random.cv_results_)

--- a/examples/sklearn_pipeline_early_stopping.py
+++ b/examples/sklearn_pipeline_early_stopping.py
@@ -1,0 +1,87 @@
+"""Example using an sklearn Pipeline with early stopping.
+
+Example taken and modified from
+https://scikit-learn.org/stable/auto_examples/compose/
+plot_compare_reduction.html
+"""
+
+from tune_sklearn import TuneSearchCV
+from tune_sklearn import TuneGridSearchCV
+from sklearn.datasets import load_digits
+from sklearn.pipeline import Pipeline
+from sklearn.linear_model import LogisticRegression, SGDClassifier
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.decomposition import PCA
+
+X, y = load_digits(return_X_y=True)
+
+# partial_fit
+
+pipe = Pipeline([("reduce_dim", PCA()), ("classify", SGDClassifier())])
+
+param_grid = [
+    {
+        "classify__alpha": [1e-4, 1e-1, 1],
+        "classify__epsilon": [0.01, 0.1]
+    },
+]
+
+random = TuneSearchCV(
+    pipe,
+    param_grid,
+    search_optimization="random",
+    early_stopping=True,
+    max_iters=10,
+    pipeline_detection=True)
+random.fit(X, y)
+print(random.cv_results_)
+
+grid = TuneGridSearchCV(
+    pipe,
+    param_grid=param_grid,
+    early_stopping=True,
+    max_iters=10,
+    pipeline_detection=True)
+grid.fit(X, y)
+print(grid.cv_results_)
+
+# warm start iter
+
+pipe = Pipeline([("reduce_dim", PCA()), ("classify", LogisticRegression())])
+
+param_grid = [
+    {
+        "classify__C": [1e-4, 1e-1, 1, 2]
+    },
+]
+
+random = TuneSearchCV(
+    pipe,
+    param_grid,
+    search_optimization="random",
+    early_stopping=True,
+    max_iters=10,
+    pipeline_detection=True)
+random.fit(X, y)
+print(random.cv_results_)
+
+# warm start ensemble
+
+pipe = Pipeline([("reduce_dim", PCA()), ("classify",
+                                         RandomForestClassifier())])
+
+param_grid = [
+    {
+        "classify__min_samples_split": [2, 3, 4]
+    },
+]
+
+random = TuneSearchCV(
+    pipe,
+    param_grid,
+    search_optimization="random",
+    early_stopping=True,
+    max_iters=10,
+    pipeline_detection=True)
+random.fit(X, y)
+print(random.cv_results_)

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -274,7 +274,7 @@ class RandomizedSearchTest(unittest.TestCase):
                 pipe,
                 parameter_grid,
                 early_stopping=True,
-                pipeline_detection=False,
+                pipeline_auto_early_stop=False,
                 max_iters=10)
         self.assertTrue((
             "Early stopping is not supported because the estimator does "

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -277,9 +277,9 @@ class RandomizedSearchTest(unittest.TestCase):
                 pipeline_detection=False,
                 max_iters=10)
         self.assertTrue((
-            "Early stopping is not supported because the estimator does not have "
-            "`partial_fit`, does not support warm_start, or is a tree "
-            "classifier. Set `early_stopping=False`."
+            "Early stopping is not supported because the estimator does "
+            "not have `partial_fit`, does not support warm_start, or "
+            "is a tree classifier. Set `early_stopping=False`."
         ) in str(exc.exception))
 
         tune_search = TuneSearchCV(

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -413,9 +413,7 @@ class _PipelineTrainable(_Trainable):
         """
         # User will not be able to fine tune the n_estimators
         # parameter using ensemble early stopping
-        updated_n_estimators = estimator.get_params(
-        )[f"{self.base_estimator_name}__n_estimators"] + 1
-        estimator.set_params(**{
-            f"{self.base_estimator_name}__n_estimators": updated_n_estimators
-        })
+        n_estimator_key = f"{self.main_estimator_name}__n_estimators"
+        updated_n_estimators = estimator.get_params()[n_estimator_key] + 1
+        estimator.set_params(**{n_estimator_key: updated_n_estimators})
         estimator.fit(X_train, y_train)

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -86,25 +86,7 @@ class _Trainable(Trainable):
         self.saved_models = []  # XGBoost specific
 
         if self.early_stopping:
-            assert self._can_early_start()
-            n_splits = self.cv.get_n_splits(self.X, self.y)
-            self.fold_scores = np.empty(n_splits, dtype=dict)
-            self.fold_train_scores = np.empty(n_splits, dtype=dict)
-            if not self._can_partial_fit() and self._can_warm_start_iter():
-                # max_iter here is different than the max_iters the user sets.
-                # max_iter is to make sklearn only fit for one epoch,
-                # while max_iters (which the user can set) is the usual max
-                # number of calls to _trainable.
-                self.estimator_config["warm_start"] = True
-                self.estimator_config["max_iter"] = 1
-
-            if not self._can_partial_fit() and self._can_warm_start_ensemble():
-                # Each additional call on a warm start ensemble only trains
-                # new estimators added to the ensemble. We start with 0
-                # and add an estimator before each call to fit in _train(),
-                # training the ensemble incrementally.
-                self.estimator_config["warm_start"] = True
-                self.estimator_config["n_estimators"] = 0
+            n_splits = self._setup_early_stopping()
 
             for i in range(n_splits):
                 self.estimator_list[i].set_params(**self.estimator_config)
@@ -113,6 +95,30 @@ class _Trainable(Trainable):
                 self.saved_models = [None for _ in range(n_splits)]
         else:
             self.main_estimator.set_params(**self.estimator_config)
+
+    def _setup_early_stopping(self):
+        assert self._can_early_start()
+        n_splits = self.cv.get_n_splits(self.X, self.y)
+        self.fold_scores = np.empty(n_splits, dtype=dict)
+        self.fold_train_scores = np.empty(n_splits, dtype=dict)
+        if not self._can_partial_fit():
+            if self._can_warm_start_iter():
+                # max_iter here is different than the max_iters the user sets.
+                # max_iter is to make sklearn only fit for one epoch,
+                # while max_iters (which the user can set) is the usual max
+                # number of calls to _trainable.
+                self.estimator_config["warm_start"] = True
+                self.estimator_config["max_iter"] = 1
+
+            elif self._can_warm_start_ensemble():
+                # Each additional call on a warm start ensemble only trains
+                # new estimators added to the ensemble. We start with 0
+                # and add an estimator before each call to fit in _train(),
+                # training the ensemble incrementally.
+                self.estimator_config["warm_start"] = True
+                self.estimator_config["n_estimators"] = 0
+
+        return n_splits
 
     def step(self):
         # forward-compatbility
@@ -314,3 +320,102 @@ class _Trainable(Trainable):
         self.config = new_config
         self._setup(new_config)
         return True
+
+
+class _PipelineTrainable(_Trainable):
+    """Class to be passed in as the first argument of tune.run to train models.
+
+    Overrides Ray Tune's Trainable class to specify the setup, train, save,
+    and restore routines.
+
+    Runs all checks and configures parameters for the last step of the Pipeline.
+
+    """
+
+    def _can_partial_fit(self):
+        return check_partial_fit(self.main_estimator.steps[-1][1])
+
+    def _can_warm_start_iter(self):
+        return check_warm_start_iter(self.main_estimator.steps[-1][1])
+
+    def _can_warm_start_ensemble(self):
+        return check_warm_start_ensemble(self.main_estimator.steps[-1][1])
+
+    def _is_xgb(self):
+        return is_xgboost_model(self.main_estimator.steps[-1][1])
+
+    def _setup_early_stopping(self):
+        assert self._can_early_start()
+        n_splits = self.cv.get_n_splits(self.X, self.y)
+        self.fold_scores = np.empty(n_splits, dtype=dict)
+        self.fold_train_scores = np.empty(n_splits, dtype=dict)
+        if not self._can_partial_fit():
+            if self._can_warm_start_iter():
+                # max_iter here is different than the max_iters the user sets.
+                # max_iter is to make sklearn only fit for one epoch,
+                # while max_iters (which the user can set) is the usual max
+                # number of calls to _trainable.
+                self.estimator_config[
+                    f"{self.main_estimator.steps[-1][0]}__warm_start"] = True
+                self.estimator_config[
+                    f"{self.main_estimator.steps[-1][0]}__max_iter"] = 1
+
+            elif self._can_warm_start_ensemble():
+                # Each additional call on a warm start ensemble only trains
+                # new estimators added to the ensemble. We start with 0
+                # and add an estimator before each call to fit in _train(),
+                # training the ensemble incrementally.
+                self.estimator_config[
+                    f"{self.main_estimator.steps[-1][0]}__warm_start"] = True
+                self.estimator_config[
+                    f"{self.main_estimator.steps[-1][0]}__n_estimators"] = 0
+
+        return n_splits
+
+    def _early_stopping_partial_fit(self, i, estimator, X_train, y_train):
+        """Handles early stopping on estimators that support `partial_fit`.
+
+        """
+        if hasattr(estimator, "partial_fit"):
+            estimator.partial_fit(X_train, y_train, np.unique(self.y))
+        else:
+            # Workaround if the pipeline itself doesn't support partial_fit
+            # (default sklearn doesn't). We set the final step to "passthrough",
+            # so that it doesn't get executed, do fit_transform to get transformed
+            # data, and then call partial_fit on just the final step.
+            last_step = estimator.steps[-1][1]
+            estimator.steps[-1] = (estimator.steps[-1][0], "passthrough")
+            X_train_transformed = estimator.fit_transform(X_train, y_train)
+            estimator.steps[-1] = (estimator.steps[-1][0], last_step)
+            estimator.steps[-1][1].partial_fit(X_train_transformed, y_train,
+                                               np.unique(self.y))
+
+    def _early_stopping_xgb(self, i, estimator, X_train, y_train):
+        """Handles early stopping on XGBoost estimators.
+
+        """
+        estimator.fit(X_train, y_train, {
+            f"{self.main_estimator.steps[-1][0]}__xgb_model": self.
+            saved_models[i]
+        })
+        self.saved_models[i] = estimator.get_booster()
+
+    def _early_stopping_iter(self, i, estimator, X_train, y_train):
+        """Handles early stopping on estimators supporting `warm_start`.
+
+        """
+        estimator.fit(X_train, y_train)
+
+    def _early_stopping_ensemble(self, i, estimator, X_train, y_train):
+        """Handles early stopping on ensemble estimators.
+
+        """
+        # User will not be able to fine tune the n_estimators
+        # parameter using ensemble early stopping
+        updated_n_estimators = estimator.get_params(
+        )[f"{self.main_estimator.steps[-1][0]}__n_estimators"] + 1
+        estimator.set_params(
+            **{
+                f"{self.main_estimator.steps[-1][0]}__n_estimators": updated_n_estimators
+            })
+        estimator.fit(X_train, y_train)

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -415,7 +415,7 @@ class _PipelineTrainable(_Trainable):
         """
         # User will not be able to fine tune the n_estimators
         # parameter using ensemble early stopping
-        n_estimator_key = f"{self.main_estimator_name}__n_estimators"
+        n_estimator_key = f"{self.base_estimator_name}__n_estimators"
         updated_n_estimators = estimator.get_params()[n_estimator_key] + 1
         estimator.set_params(**{n_estimator_key: updated_n_estimators})
         estimator.fit(X_train, y_train)

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -328,7 +328,8 @@ class _PipelineTrainable(_Trainable):
     Overrides Ray Tune's Trainable class to specify the setup, train, save,
     and restore routines.
 
-    Runs all checks and configures parameters for the last step of the Pipeline.
+    Runs all checks and configures parameters for the last step of the
+    Pipeline.
 
     """
 
@@ -388,9 +389,10 @@ class _PipelineTrainable(_Trainable):
             estimator.partial_fit(X_train, y_train, np.unique(self.y))
         else:
             # Workaround if the pipeline itself doesn't support partial_fit
-            # (default sklearn doesn't). We set the final step to "passthrough",
-            # so that it doesn't get executed, do fit_transform to get transformed
-            # data, and then call partial_fit on just the final step.
+            # (default sklearn doesn't). We set the final step to
+            # "passthrough", so that it doesn't get executed,
+            # do fit_transform to get transformed data, and then
+            # call partial_fit on just the final step.
             last_step = estimator.steps[-1][1]
             estimator.steps[-1] = (estimator.steps[-1][0], "passthrough")
             X_train_transformed = estimator.fit_transform(X_train, y_train)

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -254,14 +254,14 @@ class TuneBaseSearchCV(BaseEstimator):
                  local_dir="~/ray_results",
                  max_iters=1,
                  use_gpu=False,
-                 pipeline_detection=True):
+                 pipeline_auto_early_stop=True):
         if max_iters < 1:
             raise ValueError("max_iters must be greater than or equal to 1.")
         self.estimator = estimator
         self.base_estimator = estimator
-        self.pipeline_detection = pipeline_detection
+        self.pipeline_auto_early_stop = pipeline_auto_early_stop
 
-        if self.pipeline_detection and check_is_pipeline(estimator):
+        if self.pipeline_auto_early_stop and check_is_pipeline(estimator):
             _, self.base_estimator = self.base_estimator.steps[-1]
 
         if not self._can_early_stop():

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -118,8 +118,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             for `resources_per_trial`.
         pipeline_detection (bool): Indicates whether to attempt to enable
             early stopping support if the passed estimator is a sklearn
-            Pipeline. Early stopping will only be performed taking the 
-            last step of the pipeline into account. Defaults to True. 
+            Pipeline. Early stopping will only be performed taking the
+            last step of the pipeline into account. Defaults to True.
     """
 
     def __init__(self,

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -201,7 +201,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
 
         """
         trainable = _Trainable
-        if check_is_pipeline(self.estimator) and self.early_stopping:
+        if self.pipeline_detection and check_is_pipeline(
+                self.estimator) and self.early_stopping:
             trainable = _PipelineTrainable
 
         if self.early_stopping is not None:

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -116,10 +116,13 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will use 1 gpu
             for `resources_per_trial`.
-        pipeline_detection (bool): Indicates whether to attempt to enable
-            early stopping support if the passed estimator is a sklearn
-            Pipeline. Early stopping will only be performed taking the
-            last step of the pipeline into account. Defaults to True.
+        pipeline_auto_early_stop (bool): Only relevant if estimator is Pipeline
+            object and early_stopping is enabled/True. If True, early stopping
+            will be performed on the last stage of the pipeline (which must
+            support early stopping). If False, early stopping will be
+            determined by 'Pipeline.warm_start' or 'Pipeline.partial_fit'
+            capabilities, which are by default not supported by standard
+            SKlearn. Defaults to True.
     """
 
     def __init__(self,
@@ -137,7 +140,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                  local_dir="~/ray_results",
                  max_iters=1,
                  use_gpu=False,
-                 pipeline_detection=True):
+                 pipeline_auto_early_stop=True):
         super(TuneGridSearchCV, self).__init__(
             estimator=estimator,
             early_stopping=early_stopping,
@@ -152,7 +155,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             max_iters=max_iters,
             verbose=verbose,
             use_gpu=use_gpu,
-            pipeline_detection=pipeline_detection)
+            pipeline_auto_early_stop=pipeline_auto_early_stop)
 
         _check_param_grid(param_grid)
         self.param_grid = param_grid
@@ -201,7 +204,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
 
         """
         trainable = _Trainable
-        if self.pipeline_detection and check_is_pipeline(
+        if self.pipeline_auto_early_stop and check_is_pipeline(
                 self.estimator) and self.early_stopping:
             trainable = _PipelineTrainable
 

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -10,6 +10,7 @@ from sklearn.base import clone
 from sklearn.model_selection import ParameterGrid
 from ray import tune
 from tune_sklearn.list_searcher import ListSearcher
+from tune_sklearn.utils import check_is_pipeline
 import os
 
 
@@ -199,7 +200,9 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                 `tune.run`.
 
         """
-        trainable = _Trainable if not self.base_estimator_name else _PipelineTrainable
+        trainable = _Trainable
+        if check_is_pipeline(self.estimator) and self.early_stopping:
+            trainable = _PipelineTrainable
 
         if self.early_stopping is not None:
             config["estimator_list"] = [

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -242,10 +242,13 @@ class TuneSearchCV(TuneBaseSearchCV):
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will start processes
             with the proper CUDA VISIBLE DEVICE settings set.
-        pipeline_detection (bool): Indicates whether to attempt to enable
-            early stopping support if the passed estimator is a sklearn
-            Pipeline. Early stopping will only be performed taking the
-            last step of the pipeline into account. Defaults to True.
+        pipeline_auto_early_stop (bool): Only relevant if estimator is Pipeline
+            object and early_stopping is enabled/True. If True, early stopping
+            will be performed on the last stage of the pipeline (which must
+            support early stopping). If False, early stopping will be
+            determined by 'Pipeline.warm_start' or 'Pipeline.partial_fit'
+            capabilities, which are by default not supported by standard
+            SKlearn. Defaults to True.
         **search_kwargs (Any):
             Additional arguments to pass to the SearchAlgorithms (tune.suggest)
             objects.
@@ -270,7 +273,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                  max_iters=1,
                  search_optimization="random",
                  use_gpu=False,
-                 pipeline_detection=True,
+                 pipeline_auto_early_stop=True,
                  **search_kwargs):
         search_optimization = search_optimization.lower()
         available_optimizations = [
@@ -331,7 +334,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             local_dir=local_dir,
             max_iters=max_iters,
             use_gpu=use_gpu,
-            pipeline_detection=pipeline_detection)
+            pipeline_auto_early_stop=pipeline_auto_early_stop)
 
         self.param_distributions = param_distributions
         self.num_samples = n_trials
@@ -549,7 +552,7 @@ class TuneSearchCV(TuneBaseSearchCV):
 
         """
         trainable = _Trainable
-        if self.pipeline_detection and check_is_pipeline(
+        if self.pipeline_auto_early_stop and check_is_pipeline(
                 self.estimator) and self.early_stopping:
             trainable = _PipelineTrainable
 

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -549,7 +549,8 @@ class TuneSearchCV(TuneBaseSearchCV):
 
         """
         trainable = _Trainable
-        if check_is_pipeline(self.estimator) and self.early_stopping:
+        if self.pipeline_detection and check_is_pipeline(
+                self.estimator) and self.early_stopping:
             trainable = _PipelineTrainable
 
         stop_condition = {"training_iteration": self.max_iters}

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -2,6 +2,7 @@
     -- Anthony Yu and Michael Chau
 """
 import logging
+from tune_sklearn.utils import check_is_pipeline
 from tune_sklearn.tune_basesearch import TuneBaseSearchCV
 from tune_sklearn._trainable import _Trainable
 from tune_sklearn._trainable import _PipelineTrainable
@@ -547,7 +548,9 @@ class TuneSearchCV(TuneBaseSearchCV):
                 `tune.run`.
 
         """
-        trainable = _Trainable if not self.base_estimator_name else _PipelineTrainable
+        trainable = _Trainable
+        if check_is_pipeline(self.estimator) and self.early_stopping:
+            trainable = _PipelineTrainable
 
         stop_condition = {"training_iteration": self.max_iters}
         if self.early_stopping is not None:

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -244,8 +244,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             with the proper CUDA VISIBLE DEVICE settings set.
         pipeline_detection (bool): Indicates whether to attempt to enable
             early stopping support if the passed estimator is a sklearn
-            Pipeline. Early stopping will only be performed taking the 
-            last step of the pipeline into account. Defaults to True. 
+            Pipeline. Early stopping will only be performed taking the
+            last step of the pipeline into account. Defaults to True.
         **search_kwargs (Any):
             Additional arguments to pass to the SearchAlgorithms (tune.suggest)
             objects.

--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -1,9 +1,14 @@
 from sklearn.metrics import check_scoring
+from sklearn.pipeline import Pipeline
 import numpy as np
 
 
 def check_partial_fit(estimator):
     return callable(getattr(estimator, "partial_fit", None))
+
+
+def check_is_pipeline(estimator):
+    return isinstance(estimator, Pipeline)
 
 
 def check_warm_start_iter(estimator):


### PR DESCRIPTION
Allows to use early stopping on sklearn Pipelines. The last step (almost always the estimator) will be treated to the same early stopping checks as non-Pipeline estimators.

* Adds a new param to `TuneSearchCV` and `TuneGridSearchCV`, `pipeline_detection` (open to better name suggestions). If True, will handle early stopping if the estimator is a Pipeline.
* Added a new `_Trainable` child class, `_PipelineTrainable`, handling early stopping for Pipelines.
* Added an example.

@richardliaw 