### PR TITLE
Fix hyperopt loguniform params

### DIFF
--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -489,7 +489,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                                          f"or 'log-uniform', was {prior}")
                 if prior == "log-uniform":
                     config_space[param_name] = hp.loguniform(
-                        param_name, low, high)
+                        param_name, np.log(low), np.log(high))
                 else:
                     config_space[param_name] = hp.uniform(
                         param_name, low, high)


### PR DESCRIPTION
Hyperopt, confusingly, has bounds for it's log uniform space (`hp.loguniform`) set to `[exp(low), exp(high)]`. Therefore, in order to ensure consistency, we need to first logarithm them.