### PR TITLE
Fix of multi_metric scoring issue

### DIFF
--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -131,9 +131,8 @@ class GridSearchTest(unittest.TestCase):
             grid_search.score(X, y), grid_search_no_score.score(X, y))
 
         # giving no scoring function raises an error
-        grid_search_no_score = TuneGridSearchCV(clf_no_score, {"C": Cs})
         with self.assertRaises(TypeError) as exc:
-            grid_search_no_score.fit([[1]])
+            grid_search_no_score = TuneGridSearchCV(clf_no_score, {"C": Cs})
 
         self.assertTrue("no scoring" in str(exc.exception))
 

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -1,12 +1,12 @@
 from tune_sklearn import TuneSearchCV
 import numpy as np
 from numpy.testing import assert_array_equal
-from sklearn.datasets import make_classification
+from sklearn.datasets import make_classification, make_regression
 from sklearn.decomposition import PCA
 from scipy.stats import expon
 from sklearn.svm import SVC
 from sklearn.linear_model import LogisticRegression
-from sklearn.linear_model import SGDClassifier
+from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.pipeline import Pipeline
 from sklearn import datasets
 from skopt.space.space import Real
@@ -139,31 +139,98 @@ class RandomizedSearchTest(unittest.TestCase):
             tune_search.fit(x, y)
         self.assertTrue(wrapped_init.call_args[1]["local_mode"])
 
-    def test_multi_best(self):
+    def test_multi_best_classification(self):
         digits = datasets.load_digits()
         x = digits.data
         y = digits.target
+        model = SGDClassifier()
 
         parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}
-
         scoring = ("accuracy", "f1_micro")
+        search_methods = ['random', 'bayesian', 'hyperopt', 'bohb']
+        for search_method in search_methods:
 
-        tune_search = TuneSearchCV(
-            SGDClassifier(),
-            parameter_grid,
-            scoring=scoring,
-            max_iters=20,
-            refit="accuracy")
-        tune_search.fit(x, y)
-        self.assertAlmostEqual(
-            tune_search.best_score_,
-            max(tune_search.cv_results_["mean_test_accuracy"]),
-            places=10)
+            tune_search = TuneSearchCV(
+                model,
+                parameter_grid,
+                scoring=scoring,
+                search_optimization=search_method,
+                cv = 2,
+                n_trials=3,
+                n_jobs=1,
+                refit="accuracy")
+            tune_search.fit(x, y)
+            self.assertAlmostEqual(
+                tune_search.best_score_,
+                max(tune_search.cv_results_["mean_test_accuracy"]),
+                places=10)
 
-        p = tune_search.cv_results_["params"]
-        scores = tune_search.cv_results_["mean_test_accuracy"]
-        cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
-        self.assertEqual(tune_search.best_params_, cv_best_param)
+            p = tune_search.cv_results_["params"]
+            scores = tune_search.cv_results_["mean_test_accuracy"]
+            cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
+            self.assertEqual(tune_search.best_params_, cv_best_param)
+
+    def test_multi_best_classification_scoring_dict(self):
+        digits = datasets.load_digits()
+        x = digits.data
+        y = digits.target
+        model = SGDClassifier()
+
+        parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}
+        scoring = {'acc': 'accuracy',
+                   'f1': 'f1_micro'}
+        search_methods = ['random', 'bayesian', 'hyperopt', 'bohb']
+        for search_method in search_methods:
+
+            tune_search = TuneSearchCV(
+                model,
+                parameter_grid,
+                scoring=scoring,
+                search_optimization=search_method,
+                cv = 2,
+                n_trials=3,
+                n_jobs=1,
+                refit="acc")
+            tune_search.fit(x, y)
+            self.assertAlmostEqual(
+                tune_search.best_score_,
+                max(tune_search.cv_results_["mean_test_acc"]),
+                places=10)
+
+            p = tune_search.cv_results_["params"]
+            scores = tune_search.cv_results_["mean_test_acc"]
+            cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
+            self.assertEqual(tune_search.best_params_, cv_best_param)
+
+    def test_multi_best_regression(self):
+        x, y = make_regression(n_samples=100, n_features=10, n_informative=5)
+        model = SGDRegressor()
+        parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}
+
+        scoring = ("neg_mean_absolute_error", "neg_mean_squared_error")
+
+        search_methods = ['random', 'bayesian', 'hyperopt', 'bohb']
+        for search_method in search_methods:
+
+            tune_search = TuneSearchCV(
+                model,
+                parameter_grid,
+                scoring=scoring,
+                search_optimization=search_method,
+                cv = 2,
+                n_trials=3,
+                n_jobs=1,
+                refit="neg_mean_absolute_error")
+            tune_search.fit(x, y)
+            self.assertAlmostEqual(
+                tune_search.best_score_,
+                max(tune_search.cv_results_["mean_test_neg_mean_absolute_error"]),
+                places=10)
+
+            p = tune_search.cv_results_["params"]
+            scores = tune_search.cv_results_["mean_test_neg_mean_absolute_error"]
+            cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
+            self.assertEqual(tune_search.best_params_, cv_best_param)
 
     def test_warm_start_detection(self):
         parameter_grid = {"alpha": Real(1e-4, 1e-1, 1)}
@@ -334,7 +401,6 @@ class RandomizedSearchTest(unittest.TestCase):
         tune_search = TuneSearchCV(
             pipe, parameter_grid, early_stopping=True, max_iters=10)
         tune_search.fit(x, y)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -147,7 +147,7 @@ class RandomizedSearchTest(unittest.TestCase):
 
         parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}
         scoring = ("accuracy", "f1_micro")
-        search_methods = ['random', 'bayesian', 'hyperopt', 'bohb']
+        search_methods = ["random", "bayesian", "hyperopt", "bohb"]
         for search_method in search_methods:
 
             tune_search = TuneSearchCV(
@@ -155,7 +155,7 @@ class RandomizedSearchTest(unittest.TestCase):
                 parameter_grid,
                 scoring=scoring,
                 search_optimization=search_method,
-                cv = 2,
+                cv=2,
                 n_trials=3,
                 n_jobs=1,
                 refit="accuracy")
@@ -167,7 +167,8 @@ class RandomizedSearchTest(unittest.TestCase):
 
             p = tune_search.cv_results_["params"]
             scores = tune_search.cv_results_["mean_test_accuracy"]
-            cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
+            cv_best_param = max(
+                list(zip(scores, p)), key=lambda pair: pair[0])[1]
             self.assertEqual(tune_search.best_params_, cv_best_param)
 
     def test_multi_best_classification_scoring_dict(self):
@@ -177,9 +178,8 @@ class RandomizedSearchTest(unittest.TestCase):
         model = SGDClassifier()
 
         parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}
-        scoring = {'acc': 'accuracy',
-                   'f1': 'f1_micro'}
-        search_methods = ['random', 'bayesian', 'hyperopt', 'bohb']
+        scoring = {"acc": "accuracy", "f1": "f1_micro"}
+        search_methods = ["random", "bayesian", "hyperopt", "bohb"]
         for search_method in search_methods:
 
             tune_search = TuneSearchCV(
@@ -187,7 +187,7 @@ class RandomizedSearchTest(unittest.TestCase):
                 parameter_grid,
                 scoring=scoring,
                 search_optimization=search_method,
-                cv = 2,
+                cv=2,
                 n_trials=3,
                 n_jobs=1,
                 refit="acc")
@@ -199,7 +199,8 @@ class RandomizedSearchTest(unittest.TestCase):
 
             p = tune_search.cv_results_["params"]
             scores = tune_search.cv_results_["mean_test_acc"]
-            cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
+            cv_best_param = max(
+                list(zip(scores, p)), key=lambda pair: pair[0])[1]
             self.assertEqual(tune_search.best_params_, cv_best_param)
 
     def test_multi_best_regression(self):
@@ -209,7 +210,7 @@ class RandomizedSearchTest(unittest.TestCase):
 
         scoring = ("neg_mean_absolute_error", "neg_mean_squared_error")
 
-        search_methods = ['random', 'bayesian', 'hyperopt', 'bohb']
+        search_methods = ["random", "bayesian", "hyperopt", "bohb"]
         for search_method in search_methods:
 
             tune_search = TuneSearchCV(
@@ -217,19 +218,22 @@ class RandomizedSearchTest(unittest.TestCase):
                 parameter_grid,
                 scoring=scoring,
                 search_optimization=search_method,
-                cv = 2,
+                cv=2,
                 n_trials=3,
                 n_jobs=1,
                 refit="neg_mean_absolute_error")
             tune_search.fit(x, y)
             self.assertAlmostEqual(
                 tune_search.best_score_,
-                max(tune_search.cv_results_["mean_test_neg_mean_absolute_error"]),
+                max(tune_search.cv_results_[
+                    "mean_test_neg_mean_absolute_error"]),
                 places=10)
 
             p = tune_search.cv_results_["params"]
-            scores = tune_search.cv_results_["mean_test_neg_mean_absolute_error"]
-            cv_best_param = max(list(zip(scores, p)), key=lambda pair: pair[0])[1]
+            scores = tune_search.cv_results_[
+                "mean_test_neg_mean_absolute_error"]
+            cv_best_param = max(
+                list(zip(scores, p)), key=lambda pair: pair[0])[1]
             self.assertEqual(tune_search.best_params_, cv_best_param)
 
     def test_warm_start_detection(self):
@@ -401,6 +405,7 @@ class RandomizedSearchTest(unittest.TestCase):
         tune_search = TuneSearchCV(
             pipe, parameter_grid, early_stopping=True, max_iters=10)
         tune_search.fit(x, y)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -42,8 +42,7 @@ def resolve_early_stopping(early_stopping, max_iters, metric_name):
     if isinstance(early_stopping, str):
         if early_stopping in TuneBaseSearchCV.defined_schedulers:
             if early_stopping == "PopulationBasedTraining":
-                return PopulationBasedTraining(
-                    metric=metric_name, mode="max")
+                return PopulationBasedTraining(metric=metric_name, mode="max")
             elif early_stopping == "AsyncHyperBandScheduler":
                 return AsyncHyperBandScheduler(
                     metric=metric_name, mode="max", max_t=max_iters)
@@ -51,8 +50,7 @@ def resolve_early_stopping(early_stopping, max_iters, metric_name):
                 return HyperBandScheduler(
                     metric=metric_name, mode="max", max_t=max_iters)
             elif early_stopping == "MedianStoppingRule":
-                return MedianStoppingRule(
-                    metric=metric_name, mode="max")
+                return MedianStoppingRule(metric=metric_name, mode="max")
             elif early_stopping == "ASHAScheduler":
                 return ASHAScheduler(
                     metric=metric_name, mode="max", max_t=max_iters)
@@ -318,7 +316,7 @@ class TuneBaseSearchCV(BaseEstimator):
                 category=UserWarning)
             max_iters = 1
 
-        ## Get metric scoring name here
+        # Get metric scoring name
         self.scoring = scoring
         self.refit = refit
         if not hasattr(self, "is_multi"):
@@ -353,7 +351,8 @@ class TuneBaseSearchCV(BaseEstimator):
                 # the next block
                 early_stopping = "AsyncHyperBandScheduler"
             # Resolve the early stopping object
-            early_stopping = resolve_early_stopping(early_stopping, max_iters, self._metric_name)
+            early_stopping = resolve_early_stopping(early_stopping, max_iters,
+                                                    self._metric_name)
 
         self.early_stopping = early_stopping
         self.max_iters = max_iters
@@ -364,7 +363,6 @@ class TuneBaseSearchCV(BaseEstimator):
             self.sk_n_jobs = int(os.environ.get("SKLEARN_N_JOBS"))
         else:
             self.sk_n_jobs = sk_n_jobs
-
 
         self.verbose = verbose
         self.error_score = error_score

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -319,12 +319,6 @@ class TuneSearchCV(TuneBaseSearchCV):
                 for dist in p.values():
                     _check_distribution(dist, search_optimization)
 
-        if search_optimization == "bohb":
-            from ray.tune.schedulers import HyperBandForBOHB
-            if not isinstance(early_stopping, HyperBandForBOHB):
-                early_stopping = HyperBandForBOHB(
-                    metric="average_test_score", mode="max", max_t=max_iters)
-
         super(TuneSearchCV, self).__init__(
             estimator=estimator,
             early_stopping=early_stopping,
@@ -341,6 +335,12 @@ class TuneSearchCV(TuneBaseSearchCV):
             use_gpu=use_gpu,
             loggers=loggers,
             pipeline_auto_early_stop=pipeline_auto_early_stop)
+
+        if search_optimization == "bohb":
+            from ray.tune.schedulers import HyperBandForBOHB
+            if not isinstance(early_stopping, HyperBandForBOHB):
+                early_stopping = HyperBandForBOHB(
+                    metric=self._metric_name, mode="max", max_t=max_iters)
 
         check_error_warm_start(self.early_stop_type, param_distributions,
                                estimator)
@@ -605,7 +605,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             search_algo = SkOptSearch(
                 Optimizer(spaces),
                 hyperparameter_names,
-                metric="average_test_score",
+                metric=self._metric_name,
                 mode="max",
                 **self.search_kwargs)
 
@@ -614,7 +614,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             config_space = self._get_bohb_config_space()
             search_algo = TuneBOHB(
                 config_space,
-                metric="average_test_score",
+                metric=self._metric_name,
                 mode="max",
                 **self.search_kwargs)
 
@@ -623,7 +623,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             config_space = self._get_optuna_params()
             search_algo = OptunaSearch(
                 config_space,
-                metric="average_test_score",
+                metric=self._metric_name,
                 mode="max",
                 **self.search_kwargs)
 
@@ -632,7 +632,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             config_space = self._get_hyperopt_params()
             search_algo = HyperOptSearch(
                 config_space,
-                metric="average_test_score",
+                metric=self._metric_name,
                 mode="max",
                 **self.search_kwargs)
 


### PR DESCRIPTION
This is a fix for Issue #110, which looked to be caused by hard-coded metric names when calling other optimizers. Moving the multi_metric scoring check to the constructor (rather than in `_fit`) helped.