### PR TITLE
[WIP] `best_params` w/o `refit`, API in line with sklearn

### DIFF
--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -568,12 +568,12 @@ class GridSearchTest(unittest.TestCase):
             max_iters=20,
             refit=False)
         tune_search.fit(X, y)
-        self.assertTrue(tune_search.is_multi)
+        self.assertTrue(tune_search.multimetric_)
 
         tune_search = TuneGridSearchCV(
             SGDClassifier(), parameter_grid, scoring="f1_micro", max_iters=20)
         tune_search.fit(X, y)
-        self.assertFalse(tune_search.is_multi)
+        self.assertFalse(tune_search.multimetric_)
 
         # Make sure error is raised when refit isn't set properly
         tune_search = TuneGridSearchCV(


### PR DESCRIPTION
This PR makes `TuneBaseSearchCV` match sklearn's `BaseSearchCV` better by allowing to access various fit properties without the need of `refit=True`, as well as adds properties that were missing from `TuneBaseSearchCV` for full parity with `BaseSearchCV`.

Code is done, but it could use some extra unit tests for multimetric scoring etc. Will do that soon.