### PR TITLE
Implement resource step

### DIFF
--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -94,7 +94,8 @@ class _Trainable(Trainable):
             # new estimators added to the ensemble. We start with 0
             # and add self.resource_step estimators before each call to fit
             # in _train(), training the ensemble incrementally.
-            self.resource_step = self.main_estimator.n_estimators // self.max_iters
+            self.resource_step = (
+                self.main_estimator.n_estimators // self.max_iters)
             self.estimator_config["warm_start"] = True
             self.estimator_config["n_estimators"] = 0
 
@@ -355,15 +356,16 @@ class _PipelineTrainable(_Trainable):
             # max number of calls to _trainable.
             self.estimator_config[
                 f"{self.base_estimator_name}__warm_start"] = True
-            self.estimator_config[
-                f"{self.base_estimator_name}__max_iter"] = self.base_estimator.max_iter // self.max_iters
+            self.estimator_config[f"{self.base_estimator_name}__max_iter"] = (
+                self.base_estimator.max_iter // self.max_iters)
 
         elif self.early_stop_type == EarlyStopping.WARM_START_ENSEMBLE:
             # Each additional call on a warm start ensemble only trains
             # new estimators added to the ensemble. We start with 0
             # and add self.resource_step estimators before each call to fit
             # in _train(), training the ensemble incrementally.
-            self.resource_step = self.base_estimator.n_estimators // self.max_iters
+            self.resource_step = (
+                self.base_estimator.n_estimators // self.max_iters)
             self.estimator_config[
                 f"{self.base_estimator_name}__warm_start"] = True
             self.estimator_config[

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -82,17 +82,18 @@ class _Trainable(Trainable):
         self.fold_train_scores = np.empty(n_splits, dtype=dict)
         if self.early_stop_type == EarlyStopping.WARM_START_ITER:
             # max_iter here is different than the max_iters the user sets.
-            # max_iter is to make sklearn only fit for one epoch,
-            # while max_iters (which the user can set) is the usual max
-            # number of calls to _trainable.
+            # max_iter is to make sklearn only fit for max_iter/max_iters
+            # epochs, while max_iters (which the user can set) is the usual
+            # max number of calls to _trainable.
             self.estimator_config["warm_start"] = True
-            self.estimator_config["max_iter"] = 1
+            self.estimator_config["max_iter"] = self.main_estimator.max_iter // self.max_iters
 
         elif self.early_stop_type == EarlyStopping.WARM_START_ENSEMBLE:
             # Each additional call on a warm start ensemble only trains
             # new estimators added to the ensemble. We start with 0
-            # and add an estimator before each call to fit in _train(),
-            # training the ensemble incrementally.
+            # and add self.resource_step estimators before each call to fit
+            # in _train(), training the ensemble incrementally.
+            self.resource_step = self.main_estimator.n_estimators // self.max_iters
             self.estimator_config["warm_start"] = True
             self.estimator_config["n_estimators"] = 0
 
@@ -144,7 +145,7 @@ class _Trainable(Trainable):
         """
         # User will not be able to fine tune the n_estimators
         # parameter using ensemble early stopping
-        updated_n_estimators = estimator.get_params()["n_estimators"] + 1
+        updated_n_estimators = estimator.get_params()["n_estimators"] + self.resource_step
         estimator.set_params(**{"n_estimators": updated_n_estimators})
         estimator.fit(X_train, y_train)
 
@@ -347,18 +348,19 @@ class _PipelineTrainable(_Trainable):
         self.fold_train_scores = np.empty(n_splits, dtype=dict)
         if self.early_stop_type == EarlyStopping.WARM_START_ITER:
             # max_iter here is different than the max_iters the user sets.
-            # max_iter is to make sklearn only fit for one epoch,
-            # while max_iters (which the user can set) is the usual max
-            # number of calls to _trainable.
+            # max_iter is to make sklearn only fit for max_iter/max_iters
+            # epochs, while max_iters (which the user can set) is the usual
+            # max number of calls to _trainable.
             self.estimator_config[
                 f"{self.base_estimator_name}__warm_start"] = True
-            self.estimator_config[f"{self.base_estimator_name}__max_iter"] = 1
+            self.estimator_config[f"{self.base_estimator_name}__max_iter"] = self.main_estimator.max_iter // self.max_iters
 
         elif self.early_stop_type == EarlyStopping.WARM_START_ENSEMBLE:
             # Each additional call on a warm start ensemble only trains
             # new estimators added to the ensemble. We start with 0
-            # and add an estimator before each call to fit in _train(),
-            # training the ensemble incrementally.
+            # and add self.resource_step estimators before each call to fit
+            # in _train(), training the ensemble incrementally.
+            self.resource_step = self.main_estimator.n_estimators // self.max_iters
             self.estimator_config[
                 f"{self.base_estimator_name}__warm_start"] = True
             self.estimator_config[
@@ -426,6 +428,6 @@ class _PipelineTrainable(_Trainable):
         # User will not be able to fine tune the n_estimators
         # parameter using ensemble early stopping
         n_estimator_key = f"{self.base_estimator_name}__n_estimators"
-        updated_n_estimators = estimator.get_params()[n_estimator_key] + 1
+        updated_n_estimators = estimator.get_params()[n_estimator_key] + self.resource_step
         estimator.set_params(**{n_estimator_key: updated_n_estimators})
         estimator.fit(X_train, y_train)

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -86,7 +86,8 @@ class _Trainable(Trainable):
             # epochs, while max_iters (which the user can set) is the usual
             # max number of calls to _trainable.
             self.estimator_config["warm_start"] = True
-            self.estimator_config["max_iter"] = self.main_estimator.max_iter // self.max_iters
+            self.estimator_config[
+                "max_iter"] = self.main_estimator.max_iter // self.max_iters
 
         elif self.early_stop_type == EarlyStopping.WARM_START_ENSEMBLE:
             # Each additional call on a warm start ensemble only trains
@@ -145,7 +146,8 @@ class _Trainable(Trainable):
         """
         # User will not be able to fine tune the n_estimators
         # parameter using ensemble early stopping
-        updated_n_estimators = estimator.get_params()["n_estimators"] + self.resource_step
+        updated_n_estimators = estimator.get_params(
+        )["n_estimators"] + self.resource_step
         estimator.set_params(**{"n_estimators": updated_n_estimators})
         estimator.fit(X_train, y_train)
 
@@ -353,14 +355,15 @@ class _PipelineTrainable(_Trainable):
             # max number of calls to _trainable.
             self.estimator_config[
                 f"{self.base_estimator_name}__warm_start"] = True
-            self.estimator_config[f"{self.base_estimator_name}__max_iter"] = self.main_estimator.max_iter // self.max_iters
+            self.estimator_config[
+                f"{self.base_estimator_name}__max_iter"] = self.base_estimator.max_iter // self.max_iters
 
         elif self.early_stop_type == EarlyStopping.WARM_START_ENSEMBLE:
             # Each additional call on a warm start ensemble only trains
             # new estimators added to the ensemble. We start with 0
             # and add self.resource_step estimators before each call to fit
             # in _train(), training the ensemble incrementally.
-            self.resource_step = self.main_estimator.n_estimators // self.max_iters
+            self.resource_step = self.base_estimator.n_estimators // self.max_iters
             self.estimator_config[
                 f"{self.base_estimator_name}__warm_start"] = True
             self.estimator_config[
@@ -428,6 +431,7 @@ class _PipelineTrainable(_Trainable):
         # User will not be able to fine tune the n_estimators
         # parameter using ensemble early stopping
         n_estimator_key = f"{self.base_estimator_name}__n_estimators"
-        updated_n_estimators = estimator.get_params()[n_estimator_key] + self.resource_step
+        updated_n_estimators = estimator.get_params(
+        )[n_estimator_key] + self.resource_step
         estimator.set_params(**{n_estimator_key: updated_n_estimators})
         estimator.fit(X_train, y_train)

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -115,8 +115,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
            (`resource_param = max_iter or n_estimators`) will be detected.
            The value of `resource_param` will be treated as a
            "max resource value", and all classifiers will be
-           initialized with `max resource value // max_iters`, where 
-           `max_iters` is this defined parameter. On each epoch, 
+           initialized with `max resource value // max_iters`, where
+           `max_iters` is this defined parameter. On each epoch,
            resource_param (max_iter or n_estimators) is
            incremented by `max resource value // max_iters`.
         use_gpu (bool): Indicates whether to use gpu for fitting.

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -111,8 +111,9 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled.
             This parameter is used for early stopping. Defaults to 1.
-            When using warm start to early stop on ensembles, this will
-            determine `n_estimators` for the final refitted ensemble.`
+            When using warm start to early stop on ensembles, each iteration
+            will fit `ensemble_estimator.n_estimators // max_iters` new
+            estimators.
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will use 1 gpu
             for `resources_per_trial`.

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -111,9 +111,14 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled.
             This parameter is used for early stopping. Defaults to 1.
-            When using warm start to early stop on ensembles, each iteration
-            will fit `ensemble_estimator.n_estimators // max_iters` new
-            estimators.
+           Depending on the classifier type provided, a resource parameter
+           (`resource_param = max_iter or n_estimators`) will be detected.
+           The value of `resource_param` will be treated as a
+           "max resource value", and all classifiers will be
+           initialized with `max resource value // max_iters`, where 
+           `max_iters` is this defined parameter. On each epoch, 
+           resource_param (max_iter or n_estimators) is
+           incremented by `max resource value // max_iters`.
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will use 1 gpu
             for `resources_per_trial`.

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -225,8 +225,8 @@ class TuneSearchCV(TuneBaseSearchCV):
            (`resource_param = max_iter or n_estimators`) will be detected.
            The value of `resource_param` will be treated as a
            "max resource value", and all classifiers will be
-           initialized with `max resource value // max_iters`, where 
-           `max_iters` is this defined parameter. On each epoch, 
+           initialized with `max resource value // max_iters`, where
+           `max_iters` is this defined parameter. On each epoch,
            resource_param (max_iter or n_estimators) is
            incremented by `max resource value // max_iters`.
         search_optimization ("random" or "bayesian" or "bohb" or "hyperopt"):

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -221,9 +221,14 @@ class TuneSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_trials``).
             This parameter is used for early stopping. Defaults to 1.
-            When using warm start to early stop on ensembles, each iteration
-            will fit `ensemble_estimator.n_estimators // max_iters` new
-            estimators.
+           Depending on the classifier type provided, a resource parameter
+           (`resource_param = max_iter or n_estimators`) will be detected.
+           The value of `resource_param` will be treated as a
+           "max resource value", and all classifiers will be
+           initialized with `max resource value // max_iters`, where 
+           `max_iters` is this defined parameter. On each epoch, 
+           resource_param (max_iter or n_estimators) is
+           incremented by `max resource value // max_iters`.
         search_optimization ("random" or "bayesian" or "bohb" or "hyperopt"):
             Randomized search is invoked with ``search_optimization`` set to
             ``"random"`` and behaves like scikit-learn's

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -221,8 +221,9 @@ class TuneSearchCV(TuneBaseSearchCV):
         max_iters (int): Indicates the maximum number of epochs to run for each
             hyperparameter configuration sampled (specified by ``n_trials``).
             This parameter is used for early stopping. Defaults to 1.
-            When using warm start to early stop on ensembles, this will
-            determine `n_estimators` for the final refitted ensemble.`
+            When using warm start to early stop on ensembles, each iteration
+            will fit `ensemble_estimator.n_estimators // max_iters` new
+            estimators.
         search_optimization ("random" or "bayesian" or "bohb" or "hyperopt"):
             Randomized search is invoked with ``search_optimization`` set to
             ``"random"`` and behaves like scikit-learn's


### PR DESCRIPTION
This PR changes the behavior of how `warm_start` sklearn estimators are handled by changing the value by which the resource parameter (`max_iter` or `n_estimators`) is incremented from 1 to `base_estimator.RESOURCE_PARAM / max_iters`, where `RESOURCE_PARAM` is the resource parameter and `max_iters` is tune-sklearn's maximum number of early stopping iterations. That way, the differences between each early stopping iteration will become more pronounced, with the last iteration having CV scores equal to real scores.