### PR TITLE
Change Ray version in CI to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
     - os: linux
       python: 3.6
       env: PYTHON=3.6 OS=LINUX SKLEARN_N_JOBS=1 RAY_MASTER=1
-      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.9.0.dev0-cp36-cp36m-manylinux1_x86_64.whl
+      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp36-cp36m-manylinux1_x86_64.whl
     - os: linux
       python: 3.7
       env: PYTHON=3.7 OS=LINUX SKLEARN_N_JOBS=1 RAY_MASTER=1
-      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.9.0.dev0-cp37-cp37m-manylinux1_x86_64.whl
+      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp37-cp37m-manylinux1_x86_64.whl
     - os: osx
       osx_image: xcode9.4
       language: generic


### PR DESCRIPTION
@richardliaw in reference to https://github.com/ray-project/tune-sklearn/pull/128#issuecomment-720231501, this changes the version of Ray used in Linux CI from `0.9.0.dev0` to `1.1.0.dev0`.