### PR TITLE
Raise Errors on trial failures instead of logging them

### DIFF
--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -569,8 +569,11 @@ class GridSearchTest(unittest.TestCase):
         self.assertTrue(tune_search.multimetric_)
 
         tune_search = TuneGridSearchCV(
-            SGDClassifier(), parameter_grid, scoring="f1_micro",
-            max_iters=20, cv=2)
+            SGDClassifier(),
+            parameter_grid,
+            scoring="f1_micro",
+            max_iters=20,
+            cv=2)
         tune_search.fit(X, y)
         self.assertFalse(tune_search.multimetric_)
 

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -204,13 +204,10 @@ class GridSearchTest(unittest.TestCase):
         ]
         for cv in group_cvs:
             gs = TuneGridSearchCV(clf, grid, cv=cv)
-            try:
-                with self.assertLogs("ray.tune") as cm:
-                    gs.fit(X, y)
-                self.assertTrue((
-                    "parameter should not be None.") in str(cm.output))
-            except ValueError as exc:
-                self.assertTrue("parameter should not be None" in str(exc))
+            with self.assertRaises(ValueError) as exc:
+                gs.fit(X, y)
+            self.assertTrue(
+                "parameter should not be None" in str(exc.exception))
 
             gs.fit(X, y, groups=groups)
 
@@ -298,10 +295,10 @@ class GridSearchTest(unittest.TestCase):
 
         clf = LinearSVC()
         cv = TuneGridSearchCV(clf, {"C": [0.1, 1.0]})
-        with self.assertLogs("ray.tune") as cm:
+        with self.assertRaises(ValueError) as exc:
             cv.fit(X_[:180], y_)
-        self.assertTrue(("ValueError: Found input variables with inconsistent "
-                         "numbers of samples: [180, 200]") in str(cm.output))
+        self.assertTrue(("Found input variables with inconsistent numbers of "
+                         "samples: [180, 200]") in str(exc.exception))
 
     def test_grid_search_one_grid_point(self):
         X_, y_ = make_classification(
@@ -429,11 +426,11 @@ class GridSearchTest(unittest.TestCase):
         # test error is raised when the precomputed kernel is not array-like
         # or sparse
         # with self.assertRaises(TuneError):
-        with self.assertLogs("ray.tune") as cm:
+        with self.assertRaises(ValueError) as exc:
             cv.fit(K_train.tolist(), y_train)
-        self.assertTrue((
-            "ValueError: Precomputed kernels or affinity matrices have "
-            "to be passed as arrays or sparse matrices.") in str(cm.output))
+        self.assertTrue(("Precomputed kernels or affinity matrices have "
+                         "to be passed as arrays or sparse matrices."
+                         ) in str(exc.exception))
 
     def test_grid_search_precomputed_kernel_error_nonsquare(self):
         # Test that grid search returns an error with a non-square precomputed
@@ -443,10 +440,10 @@ class GridSearchTest(unittest.TestCase):
         clf = SVC(kernel="precomputed")
         cv = TuneGridSearchCV(clf, {"C": [0.1, 1.0]})
         # with self.assertRaises(TuneError):
-        with self.assertLogs("ray.tune") as cm:
+        with self.assertRaises(ValueError) as exc:
             cv.fit(K_train, y_train)
-        self.assertTrue(("ValueError: X should be a square kernel matrix"
-                         ) in str(cm.output))
+        self.assertTrue((
+            "X should be a square kernel matrix") in str(exc.exception))
 
     def test_refit(self):
         # Regression test for bug in refitting

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -565,7 +565,7 @@ class GridSearchTest(unittest.TestCase):
             parameter_grid,
             scoring=("accuracy", "f1_micro"),
             max_iters=20,
-            cv=5,
+            cv=2,
             refit=False)
         tune_search.fit(X, y)
         self.assertTrue(tune_search.multimetric_)

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -563,12 +563,14 @@ class GridSearchTest(unittest.TestCase):
             parameter_grid,
             scoring=("accuracy", "f1_micro"),
             max_iters=20,
+            cv=5,
             refit=False)
         tune_search.fit(X, y)
         self.assertTrue(tune_search.multimetric_)
 
         tune_search = TuneGridSearchCV(
-            SGDClassifier(), parameter_grid, scoring="f1_micro", max_iters=20)
+            SGDClassifier(), parameter_grid, scoring="f1_micro",
+            max_iters=20, cv=2)
         tune_search.fit(X, y)
         self.assertFalse(tune_search.multimetric_)
 
@@ -577,6 +579,7 @@ class GridSearchTest(unittest.TestCase):
             SGDClassifier(),
             parameter_grid,
             scoring=("accuracy", "f1_micro"),
+            cv=2,
             max_iters=20)
         with self.assertRaises(ValueError):
             tune_search.fit(X, y)

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -1,6 +1,5 @@
 """ Helper class to train models using Ray backend
 """
-
 import ray
 from ray.tune import Trainable
 from sklearn.base import clone
@@ -14,7 +13,6 @@ import warnings
 import inspect
 
 from tune_sklearn.utils import (EarlyStopping, _aggregate_score_dicts)
-
 
 class _Trainable(Trainable):
     """Class to be passed in as the first argument of tune.run to train models.
@@ -260,13 +258,6 @@ class _Trainable(Trainable):
                     scoring=self.scoring,
                     return_train_score=self.return_train_score,
                 )
-            except ValueError as e:
-                if "n_splits" in str(e):
-                    raise ValueError(
-                        str(e) + "Try reducing the number of "
-                        "splits by setting the `cv` "
-                        "parameter of your Tune Search "
-                        "object.")
 
             ret = {}
             for name in self.scoring:

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -262,12 +262,11 @@ class _Trainable(Trainable):
                 )
             except ValueError as e:
                 if "n_splits" in str(e):
-                    raise ValueError(str(e)+"Try reducing the number of "
-                                            "splits by setting the `cv` "
-                                            "parameter of your Tune Search "
-                                            "object.")
-
-
+                    raise ValueError(
+                        str(e) + "Try reducing the number of "
+                        "splits by setting the `cv` "
+                        "parameter of your Tune Search "
+                        "object.")
 
             ret = {}
             for name in self.scoring:

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -260,6 +260,14 @@ class _Trainable(Trainable):
                     scoring=self.scoring,
                     return_train_score=self.return_train_score,
                 )
+            except ValueError as e:
+                if "n_splits" in str(e):
+                    raise ValueError(str(e)+"Try reducing the number of "
+                                            "splits by setting the `cv` "
+                                            "parameter of your Tune Search "
+                                            "object.")
+
+
 
             ret = {}
             for name in self.scoring:

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -627,7 +627,6 @@ class TuneBaseSearchCV(BaseEstimator):
             :obj:`TuneBaseSearchCV` child instance, after fitting.
 
         """
-        logger.error("Test test")
         ray_init = ray.is_initialized()
         try:
             if not ray_init:

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -657,7 +657,8 @@ class TuneBaseSearchCV(BaseEstimator):
         except Exception as e:
             if not ray_init and ray.is_initialized():
                 ray.shutdown()
-            raise e
+            if type(e) != TuneError:
+                raise
 
     def score(self, X, y=None):
         """Compute the score(s) of an estimator on a given test set.

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -627,6 +627,7 @@ class TuneBaseSearchCV(BaseEstimator):
             :obj:`TuneBaseSearchCV` child instance, after fitting.
 
         """
+        logger.error("Test test")
         ray_init = ray.is_initialized()
         try:
             if not ray_init:
@@ -657,8 +658,7 @@ class TuneBaseSearchCV(BaseEstimator):
         except Exception as e:
             if not ray_init and ray.is_initialized():
                 ray.shutdown()
-            if type(e) != TuneError:
-                raise
+            raise e
 
     def score(self, X, y=None):
         """Compute the score(s) of an estimator on a given test set.

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -24,7 +24,6 @@ from ray.tune.schedulers import (
     MedianStoppingRule, TrialScheduler, ASHAScheduler)
 from ray.tune.logger import (TBXLogger, JsonLogger, CSVLogger, MLFLowLogger,
                              Logger)
-from ray.tune.error import TuneError
 import numpy as np
 from numpy.ma import MaskedArray
 import warnings
@@ -654,7 +653,7 @@ class TuneBaseSearchCV(BaseEstimator):
 
             return result
 
-        except Exception as e:
+        except Exception:
             if not ray_init and ray.is_initialized():
                 ray.shutdown()
             raise

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -657,8 +657,7 @@ class TuneBaseSearchCV(BaseEstimator):
         except Exception as e:
             if not ray_init and ray.is_initialized():
                 ray.shutdown()
-            if type(e) != TuneError:
-                raise
+            raise
 
     def score(self, X, y=None):
         """Compute the score(s) of an estimator on a given test set.

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -1,6 +1,7 @@
 """Class for doing grid search over lists of hyperparameters
     -- Anthony Yu and Michael Chau
 """
+import warnings
 
 from tune_sklearn.tune_basesearch import TuneBaseSearchCV
 from tune_sklearn._trainable import _Trainable
@@ -228,31 +229,33 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         else:
             config["estimator_list"] = [self.estimator]
 
-        if isinstance(self.param_grid, list):
-            analysis = tune.run(
-                trainable,
-                search_alg=ListSearcher(self.param_grid),
-                num_samples=self._list_grid_num_samples(),
-                scheduler=self.early_stopping,
-                reuse_actors=True,
-                verbose=self.verbose,
-                stop={"training_iteration": self.max_iters},
-                config=config,
-                fail_fast="raise",
-                resources_per_trial=resources_per_trial,
-                local_dir=os.path.expanduser(self.local_dir),
-                loggers=self.loggers)
-        else:
-            analysis = tune.run(
-                trainable,
-                scheduler=self.early_stopping,
-                reuse_actors=True,
-                verbose=self.verbose,
-                stop={"training_iteration": self.max_iters},
-                config=config,
-                fail_fast="raise",
-                resources_per_trial=resources_per_trial,
-                local_dir=os.path.expanduser(self.local_dir),
-                loggers=self.loggers)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if isinstance(self.param_grid, list):
+                analysis = tune.run(
+                    trainable,
+                    search_alg=ListSearcher(self.param_grid),
+                    num_samples=self._list_grid_num_samples(),
+                    scheduler=self.early_stopping,
+                    reuse_actors=True,
+                    verbose=self.verbose,
+                    stop={"training_iteration": self.max_iters},
+                    config=config,
+                    fail_fast="raise",
+                    resources_per_trial=resources_per_trial,
+                    local_dir=os.path.expanduser(self.local_dir),
+                    loggers=self.loggers)
+            else:
+                analysis = tune.run(
+                    trainable,
+                    scheduler=self.early_stopping,
+                    reuse_actors=True,
+                    verbose=self.verbose,
+                    stop={"training_iteration": self.max_iters},
+                    config=config,
+                    fail_fast="raise",
+                    resources_per_trial=resources_per_trial,
+                    local_dir=os.path.expanduser(self.local_dir),
+                    loggers=self.loggers)
 
         return analysis

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -255,6 +255,6 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", message="fail_fast='raise' "
-                                  "detected.")
+                "detected.")
             analysis = tune.run(trainable, **run_args)
         return analysis

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -240,7 +240,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             verbose=self.verbose,
             stop={"training_iteration": self.max_iters},
             config=config,
-            fail_fast=True,
+            fail_fast="raise",
             resources_per_trial=resources_per_trial,
             local_dir=os.path.expanduser(self.local_dir),
             loggers=self.loggers,

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -230,7 +230,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             config["estimator_list"] = [self.estimator]
 
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.filterwarnings("ignore", message="fail_fast='raise' "
+                                                  "detected.")
             if isinstance(self.param_grid, list):
                 analysis = tune.run(
                     trainable,

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -230,8 +230,9 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             config["estimator_list"] = [self.estimator]
 
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="fail_fast='raise' "
-                                                  "detected.")
+            warnings.filterwarnings(
+                "ignore", message="fail_fast='raise' "
+                "detected.")
             if isinstance(self.param_grid, list):
                 analysis = tune.run(
                     trainable,

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -238,7 +238,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                 verbose=self.verbose,
                 stop={"training_iteration": self.max_iters},
                 config=config,
-                fail_fast=True,
+                fail_fast="raise",
                 resources_per_trial=resources_per_trial,
                 local_dir=os.path.expanduser(self.local_dir),
                 loggers=self.loggers)
@@ -250,7 +250,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                 verbose=self.verbose,
                 stop={"training_iteration": self.max_iters},
                 config=config,
-                fail_fast=True,
+                fail_fast="raise",
                 resources_per_trial=resources_per_trial,
                 local_dir=os.path.expanduser(self.local_dir),
                 loggers=self.loggers)

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -599,9 +599,10 @@ class TuneSearchCV(TuneBaseSearchCV):
             if isinstance(self.param_distributions, list):
                 run_args["search_alg"] = RandomListSearcher(
                     self.param_distributions)
-
-            analysis = tune.run(trainable, **run_args)
-            return analysis
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                analysis = tune.run(trainable, **run_args)
+                return analysis
 
         elif self.search_optimization == "bayesian":
             from skopt import Optimizer
@@ -645,18 +646,20 @@ class TuneSearchCV(TuneBaseSearchCV):
             search_algo = ConcurrencyLimiter(
                 search_algo, max_concurrent=self.n_jobs)
 
-        analysis = tune.run(
-            trainable,
-            search_alg=search_algo,
-            scheduler=self.early_stopping,
-            reuse_actors=True,
-            verbose=self.verbose,
-            stop=stop_condition,
-            num_samples=self.num_samples,
-            config=config,
-            fail_fast="raise",
-            resources_per_trial=resources_per_trial,
-            local_dir=os.path.expanduser(self.local_dir),
-            loggers=self.loggers)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            analysis = tune.run(
+                trainable,
+                search_alg=search_algo,
+                scheduler=self.early_stopping,
+                reuse_actors=True,
+                verbose=self.verbose,
+                stop=stop_condition,
+                num_samples=self.num_samples,
+                config=config,
+                fail_fast="raise",
+                resources_per_trial=resources_per_trial,
+                local_dir=os.path.expanduser(self.local_dir),
+                loggers=self.loggers)
 
         return analysis

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -591,7 +591,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                 stop=stop_condition,
                 num_samples=self.num_samples,
                 config=config,
-                fail_fast=True,
+                fail_fast="raise",
                 resources_per_trial=resources_per_trial,
                 local_dir=os.path.expanduser(self.local_dir),
                 loggers=self.loggers)
@@ -654,7 +654,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             stop=stop_condition,
             num_samples=self.num_samples,
             config=config,
-            fail_fast=True,
+            fail_fast="raise",
             resources_per_trial=resources_per_trial,
             local_dir=os.path.expanduser(self.local_dir),
             loggers=self.loggers)

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -600,8 +600,9 @@ class TuneSearchCV(TuneBaseSearchCV):
                 run_args["search_alg"] = RandomListSearcher(
                     self.param_distributions)
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message="fail_fast='raise' "
-                                                          "detected.")
+                warnings.filterwarnings(
+                    "ignore", message="fail_fast='raise' "
+                    "detected.")
                 analysis = tune.run(trainable, **run_args)
                 return analysis
 
@@ -648,8 +649,9 @@ class TuneSearchCV(TuneBaseSearchCV):
                 search_algo, max_concurrent=self.n_jobs)
 
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="fail_fast='raise' "
-                                                      "detected.")
+            warnings.filterwarnings(
+                "ignore", message="fail_fast='raise' "
+                "detected.")
             analysis = tune.run(
                 trainable,
                 search_alg=search_algo,

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -674,6 +674,6 @@ class TuneSearchCV(TuneBaseSearchCV):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", message="fail_fast='raise' "
-                                  "detected.")
+                "detected.")
             analysis = tune.run(trainable, **run_args)
         return analysis

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -604,7 +604,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             stop=stop_condition,
             num_samples=self.num_samples,
             config=config,
-            fail_fast=True,
+            fail_fast="raise",
             resources_per_trial=resources_per_trial,
             local_dir=os.path.expanduser(self.local_dir),
             loggers=self.loggers,

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -600,7 +600,8 @@ class TuneSearchCV(TuneBaseSearchCV):
                 run_args["search_alg"] = RandomListSearcher(
                     self.param_distributions)
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
+                warnings.filterwarnings("ignore", message="fail_fast='raise' "
+                                                          "detected.")
                 analysis = tune.run(trainable, **run_args)
                 return analysis
 
@@ -647,7 +648,8 @@ class TuneSearchCV(TuneBaseSearchCV):
                 search_algo, max_concurrent=self.n_jobs)
 
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.filterwarnings("ignore", message="fail_fast='raise' "
+                                                      "detected.")
             analysis = tune.run(
                 trainable,
                 search_alg=search_algo,


### PR DESCRIPTION
This PR raises underlying errors on trial failure instead of simply just logging them and catching the exception.

Closes #108. 

Depends on https://github.com/ray-project/ray/pull/11842

When running the following code:
```
import numpy as np
from tune_sklearn import TuneGridSearchCV
from sklearn.model_selection import GridSearchCV
from sklearn.linear_model import Ridge, SGDClassifier
parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}


X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1], [2, 1]])
y = np.array([1, 1, 2, 2, 2])


tune_search = TuneGridSearchCV(
    SGDClassifier(), parameter_grid, scoring="f1_micro", max_iters=20)
tune_search.fit(X, y)
print("Success!")
```

this is the stacktrace without this PR:
```
/Users/amog/dev/tune-sklearn/tune_sklearn/tune_basesearch.py:391: UserWarning: max_iters is set > 1 but incremental/partial training is not enabled. To enable partial training, ensure the estimator has `partial_fit` or `warm_start` and set `early_stopping=True`. Automatically setting max_iters=1.
  category=UserWarning)
Trial _Trainable_7be32_00001: Error processing event.
Traceback (most recent call last):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/trial_runner.py", line 547, in _process_trial
    result = self.trial_executor.fetch_result(trial)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/ray_trial_executor.py", line 484, in fetch_result
    result = ray.get(trial_future[0], timeout=DEFAULT_GET_TIMEOUT)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/worker.py", line 1449, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::_Trainable.train() (pid=73967, ip=192.168.2.228)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/queue.py", line 167, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

ray::_Trainable.train() (pid=73967, ip=192.168.2.228)
  File "python/ray/_raylet.pyx", line 477, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 481, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 482, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 436, in ray._raylet.execute_task.function_executor
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/trainable.py", line 183, in train
    result = self.step()
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/_trainable.py", line 106, in step
    return self._train()
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/_trainable.py", line 247, in _train
    return_train_score=self.return_train_score,
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/utils/validation.py", line 72, in inner_f
    return f(**kwargs)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_validation.py", line 248, in cross_validate
    for train, test in cv.split(X, y, groups))
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/joblib/parallel.py", line 1029, in __call__
    if self.dispatch_one_batch(iterator):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/joblib/parallel.py", line 819, in dispatch_one_batch
    islice = list(itertools.islice(iterator, big_batch_size))
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_validation.py", line 243, in <genexpr>
    delayed(_fit_and_score)(
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 336, in split
    for train, test in super().split(X, y, groups):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 80, in split
    for test_index in self._iter_test_masks(X, y, groups):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 697, in _iter_test_masks
    test_folds = self._make_test_folds(X, y)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 668, in _make_test_folds
    % (self.n_splits))
ValueError: n_splits=5 cannot be greater than the number of members in each class.
Success!
```
Notice how the errors are logged, but not raised so program execution still continues.

With this PR:
```
/Users/amog/dev/tune-sklearn/tune_sklearn/tune_basesearch.py:391: UserWarning: max_iters is set > 1 but incremental/partial training is not enabled. To enable partial training, ensure the estimator has `partial_fit` or `warm_start` and set `early_stopping=True`. Automatically setting max_iters=1.
  category=UserWarning)
Trial _Trainable_568d9_00002: Error processing event.
Traceback (most recent call last):
  File "test.py", line 14, in <module>
    tune_search.fit(X, y)
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/tune_basesearch.py", line 650, in fit
    result = self._fit(X, y, groups, **fit_params)
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/tune_basesearch.py", line 551, in _fit
    analysis = self._tune_run(config, resources_per_trial)
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/tune_gridsearch.py", line 259, in _tune_run
    loggers=self.loggers)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/tune.py", line 416, in run
    runner.step()
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/trial_runner.py", line 389, in step
    self._process_events()  # blocking
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/trial_runner.py", line 532, in _process_events
    self._process_trial(trial)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/trial_runner.py", line 547, in _process_trial
    result = self.trial_executor.fetch_result(trial)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/ray_trial_executor.py", line 484, in fetch_result
    result = ray.get(trial_future[0], timeout=DEFAULT_GET_TIMEOUT)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/worker.py", line 1449, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::_Trainable.train() (pid=73844, ip=192.168.2.228)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/queue.py", line 167, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

ray::_Trainable.train() (pid=73844, ip=192.168.2.228)
  File "python/ray/_raylet.pyx", line 477, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 481, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 482, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 436, in ray._raylet.execute_task.function_executor
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/ray/tune/trainable.py", line 183, in train
    result = self.step()
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/_trainable.py", line 106, in step
    return self._train()
  File "/Users/amog/dev/tune-sklearn/tune_sklearn/_trainable.py", line 247, in _train
    return_train_score=self.return_train_score,
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/utils/validation.py", line 72, in inner_f
    return f(**kwargs)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_validation.py", line 248, in cross_validate
    for train, test in cv.split(X, y, groups))
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/joblib/parallel.py", line 1029, in __call__
    if self.dispatch_one_batch(iterator):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/joblib/parallel.py", line 819, in dispatch_one_batch
    islice = list(itertools.islice(iterator, big_batch_size))
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_validation.py", line 243, in <genexpr>
    delayed(_fit_and_score)(
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 336, in split
    for train, test in super().split(X, y, groups):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 80, in split
    for test_index in self._iter_test_masks(X, y, groups):
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 697, in _iter_test_masks
    test_folds = self._make_test_folds(X, y)
  File "/Users/amog/dev/ray/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 668, in _make_test_folds
    % (self.n_splits))
ValueError: n_splits=5 cannot be greater than the number of members in each class.
```