### PR TITLE
Add `time_budget_s` parameter

### DIFF
--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -1,3 +1,5 @@
+import time
+
 import ray
 from tune_sklearn import TuneGridSearchCV
 from tune_sklearn import TuneSearchCV
@@ -35,7 +37,7 @@ from sklearn.neighbors import KernelDensity
 import unittest
 from unittest.mock import patch
 from test_utils import (MockClassifier, CheckingClassifier, BrokenClassifier,
-                        MockDataFrame)
+                        SleepClassifier, MockDataFrame)
 
 # def test_check_cv_results_array_types(self, cv_results, param_keys,
 #                                       score_keys):
@@ -696,6 +698,27 @@ class GridSearchTest(unittest.TestCase):
 
         self.assertTrue(hasattr(grid_search, "cv_results_"))
         self.assertTrue(wrapped_init.call_args[1]["local_mode"])
+
+    def test_timeout(self):
+        clf = SleepClassifier()
+        # SleepClassifier sleeps for `foo_param` seconds, `cv` times.
+        # Thus, the time budget is exhausted after testing the first two
+        # `foo_param`s.
+        grid_search = TuneGridSearchCV(
+            clf, {"foo_param": [1.1, 1.2, 2.5]},
+            time_budget_s=5.0,
+            cv=2,
+            max_iters=5,
+            early_stopping=True)
+
+        start = time.time()
+        grid_search.fit(X, y)
+        taken = time.time() - start
+
+        print(grid_search)
+        # Without timeout we would need over 50 seconds for this to
+        # finish. Allow for some initialization overhead
+        self.assertLess(taken, 18.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.validation import _num_samples, check_array
@@ -7,9 +9,11 @@ class MockClassifier:
     """Dummy classifier to test the parameter search algorithms"""
 
     def __init__(self, foo_param=0):
+        self.count = 0
         self.foo_param = foo_param
 
     def fit(self, X, Y):
+        self.count += 1
         assert len(X) == len(Y)
         self.classes_ = np.unique(Y)
         return self
@@ -38,6 +42,18 @@ class MockClassifier:
     def set_params(self, **params):
         self.foo_param = params["foo_param"]
         return self
+
+
+class SleepClassifier(MockClassifier):
+    def fit(self, X, Y):
+        time.sleep(self.foo_param)
+        return super().fit(X, Y)
+
+    def partial_fit(self, X, Y):
+        return self.fit(X, Y)
+
+    def score(self, X=None, Y=None):
+        return self.foo_param
 
 
 class CheckingClassifier(BaseEstimator, ClassifierMixin):

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -361,12 +361,14 @@ class TuneBaseSearchCV(BaseEstimator):
                  max_iters=1,
                  use_gpu=False,
                  loggers=None,
-                 pipeline_auto_early_stop=True):
+                 pipeline_auto_early_stop=True,
+                 time_budget_s=None):
         if max_iters < 1:
             raise ValueError("max_iters must be greater than or equal to 1.")
         self.estimator = estimator
         self.base_estimator = estimator
         self.pipeline_auto_early_stop = pipeline_auto_early_stop
+        self.time_budget_s = time_budget_s
 
         if self.pipeline_auto_early_stop and check_is_pipeline(estimator):
             _, self.base_estimator = self.base_estimator.steps[-1]

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -132,6 +132,9 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             determined by 'Pipeline.warm_start' or 'Pipeline.partial_fit'
             capabilities, which are by default not supported by standard
             SKlearn. Defaults to True.
+        time_budget_s (int|float|datetime.timedelta): Global time budget in
+            seconds after which all trials are stopped. Can also be a
+            ``datetime.timedelta`` object.
     """
 
     def __init__(self,
@@ -150,7 +153,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                  max_iters=1,
                  use_gpu=False,
                  loggers=None,
-                 pipeline_auto_early_stop=True):
+                 pipeline_auto_early_stop=True,
+                 time_budget_s=None):
         super(TuneGridSearchCV, self).__init__(
             estimator=estimator,
             early_stopping=early_stopping,
@@ -166,7 +170,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             verbose=verbose,
             use_gpu=use_gpu,
             loggers=loggers,
-            pipeline_auto_early_stop=pipeline_auto_early_stop)
+            pipeline_auto_early_stop=pipeline_auto_early_stop,
+            time_budget_s=time_budget_s)
 
         check_error_warm_start(self.early_stop_type, param_grid, estimator)
 
@@ -237,7 +242,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             fail_fast=True,
             resources_per_trial=resources_per_trial,
             local_dir=os.path.expanduser(self.local_dir),
-            loggers=self.loggers)
+            loggers=self.loggers,
+            time_budget_s=self.time_budget_s)
 
         if isinstance(self.param_grid, list):
             run_args.update(

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -228,31 +228,22 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         else:
             config["estimator_list"] = [self.estimator]
 
-        if isinstance(self.param_grid, list):
-            analysis = tune.run(
-                trainable,
-                search_alg=ListSearcher(self.param_grid),
-                num_samples=self._list_grid_num_samples(),
-                scheduler=self.early_stopping,
-                reuse_actors=True,
-                verbose=self.verbose,
-                stop={"training_iteration": self.max_iters},
-                config=config,
-                fail_fast=True,
-                resources_per_trial=resources_per_trial,
-                local_dir=os.path.expanduser(self.local_dir),
-                loggers=self.loggers)
-        else:
-            analysis = tune.run(
-                trainable,
-                scheduler=self.early_stopping,
-                reuse_actors=True,
-                verbose=self.verbose,
-                stop={"training_iteration": self.max_iters},
-                config=config,
-                fail_fast=True,
-                resources_per_trial=resources_per_trial,
-                local_dir=os.path.expanduser(self.local_dir),
-                loggers=self.loggers)
+        run_args = dict(
+            scheduler=self.early_stopping,
+            reuse_actors=True,
+            verbose=self.verbose,
+            stop={"training_iteration": self.max_iters},
+            config=config,
+            fail_fast=True,
+            resources_per_trial=resources_per_trial,
+            local_dir=os.path.expanduser(self.local_dir),
+            loggers=self.loggers)
 
+        if isinstance(self.param_grid, list):
+            run_args.update(
+                dict(
+                    search_alg=ListSearcher(self.param_grid),
+                    num_samples=self._list_grid_num_samples()))
+
+        analysis = tune.run(trainable, **run_args)
         return analysis

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -664,7 +664,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             raise ValueError(
                 f"Invalid search optimizer: {self.search_optimization}")
 
-        if isinstance(self.n_jobs, int) and self.n_jobs > 0:
+        if isinstance(self.n_jobs, int) and self.n_jobs > 0 \
+           and not self.search_optimization == "random":
             search_algo = ConcurrencyLimiter(
                 search_algo, max_concurrent=self.n_jobs)
             run_args["search_alg"] = search_algo

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -258,6 +258,9 @@ class TuneSearchCV(TuneBaseSearchCV):
             determined by 'Pipeline.warm_start' or 'Pipeline.partial_fit'
             capabilities, which are by default not supported by standard
             SKlearn. Defaults to True.
+        time_budget_s (int|float|datetime.timedelta): Global time budget in
+            seconds after which all trials are stopped. Can also be a
+            ``datetime.timedelta`` object.
         **search_kwargs (Any):
             Additional arguments to pass to the SearchAlgorithms (tune.suggest)
             objects.
@@ -284,6 +287,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                  use_gpu=False,
                  loggers=None,
                  pipeline_auto_early_stop=True,
+                 time_budget_s=None,
                  **search_kwargs):
         search_optimization = search_optimization.lower()
         available_optimizations = [
@@ -339,7 +343,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             max_iters=max_iters,
             use_gpu=use_gpu,
             loggers=loggers,
-            pipeline_auto_early_stop=pipeline_auto_early_stop)
+            pipeline_auto_early_stop=pipeline_auto_early_stop,
+            time_budget_s=time_budget_s)
 
         if search_optimization == "bohb":
             from ray.tune.schedulers import HyperBandForBOHB
@@ -593,7 +598,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             fail_fast=True,
             resources_per_trial=resources_per_trial,
             local_dir=os.path.expanduser(self.local_dir),
-            loggers=self.loggers)
+            loggers=self.loggers,
+            time_budget_s=self.time_budget_s)
 
         if self.search_optimization == "random":
             if isinstance(self.param_distributions, list):

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -260,7 +260,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             SKlearn. Defaults to True.
         time_budget_s (int|float|datetime.timedelta): Global time budget in
             seconds after which all trials are stopped. Can also be a
-            ``datetime.timedelta`` object.
+            ``datetime.timedelta`` object. The stopping condition is checked
+            after receiving a result, i.e. after each training iteration.
         **search_kwargs (Any):
             Additional arguments to pass to the SearchAlgorithms (tune.suggest)
             objects.


### PR DESCRIPTION
This passes the `time_budget_s` parameter to `tune.run()`.

This also refactors parts of the base search `_format_results()` method to deal with missing values from trials (that e.g. have not been received due to early stopping/timeout).