### PR TITLE
Use fractional GPUs for a Ray cluster

### DIFF
--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -122,8 +122,10 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             resource_param (max_iter or n_estimators) is
             incremented by `max resource value // max_iters`.
         use_gpu (bool): Indicates whether to use gpu for fitting.
-            Defaults to False. If True, training will use 1 gpu
-            for `resources_per_trial`.
+            Defaults to False. If True, training will start processes
+            with the proper CUDA VISIBLE DEVICE settings set. If a Ray
+            cluster has been initialized, all available GPUs will
+            be used.
         loggers (list): A list of the names of the Tune loggers as strings
             to be used to log results. Possible values are "tensorboard",
             "csv", "mlflow", and "json"

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -254,7 +254,9 @@ class TuneSearchCV(TuneBaseSearchCV):
             libraries to be installed.
         use_gpu (bool): Indicates whether to use gpu for fitting.
             Defaults to False. If True, training will start processes
-            with the proper CUDA VISIBLE DEVICE settings set.
+            with the proper CUDA VISIBLE DEVICE settings set. If a Ray
+            cluster has been initialized, all available GPUs will
+            be used.
         loggers (list): A list of the names of the Tune loggers as strings
             to be used to log results. Possible values are "tensorboard",
             "csv", "mlflow", and "json"


### PR DESCRIPTION
Solves https://github.com/ray-project/tune-sklearn/issues/143.

I am not *entirely* sure if this is the full solution to the issue, but I assumed that it would be only applicable to a Ray cluster. Therefore, the new behavior is to query Ray for the number of available GPUs and assign a fraction of them to each trial in the exact same way CPUs are assigned.