### PR TITLE
Avoid Loky Pickle Error

### DIFF
--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -358,7 +358,6 @@ class TuneBaseSearchCV(BaseEstimator):
                  early_stopping=None,
                  scoring=None,
                  n_jobs=None,
-                 sk_n_jobs=-1,
                  cv=5,
                  refit=True,
                  verbose=0,
@@ -465,10 +464,9 @@ class TuneBaseSearchCV(BaseEstimator):
 
         self.cv = cv
         self.n_jobs = int(n_jobs or -1)
+        self.sk_n_jobs = 1
         if os.environ.get("SKLEARN_N_JOBS") is not None:
             self.sk_n_jobs = int(os.environ.get("SKLEARN_N_JOBS"))
-        else:
-            self.sk_n_jobs = sk_n_jobs
 
         self.verbose = verbose
         self.error_score = error_score

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -154,7 +154,12 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                  use_gpu=False,
                  loggers=None,
                  pipeline_auto_early_stop=True,
-                 time_budget_s=None):
+                 time_budget_s=None,
+                 sk_n_jobs=None):
+        if sk_n_jobs is not None:
+            raise ValueError(
+                "Tune-sklearn no longer supports nested parallelism "
+                "with new versions of joblib/sklearn. Don't set 'sk_n_jobs'.")
         super(TuneGridSearchCV, self).__init__(
             estimator=estimator,
             early_stopping=early_stopping,

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -64,9 +64,6 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             will be run using Ray's 'local mode'. This can
             lead to significant speedups if the model takes < 10 seconds
             to fit due to removing inter-process communication overheads.
-        sk_n_jobs (int): Number of jobs to run in parallel for cross validating
-            each hyperparameter set; the ``n_jobs`` parameter for
-            ``cross_validate`` call to sklearn when early stopping isn't used.
         cv (int, `cross-validation generator` or `iterable`): Determines the
             cross-validation splitting strategy. Possible inputs for cv are:
 
@@ -147,7 +144,6 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                  early_stopping=None,
                  scoring=None,
                  n_jobs=None,
-                 sk_n_jobs=-1,
                  cv=5,
                  refit=True,
                  verbose=0,
@@ -164,7 +160,6 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             early_stopping=early_stopping,
             scoring=scoring,
             n_jobs=n_jobs or -1,
-            sk_n_jobs=sk_n_jobs,
             cv=cv,
             refit=refit,
             error_score=error_score,

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -295,7 +295,12 @@ class TuneSearchCV(TuneBaseSearchCV):
                  loggers=None,
                  pipeline_auto_early_stop=True,
                  time_budget_s=None,
+                 sk_n_jobs=None,
                  **search_kwargs):
+        if sk_n_jobs is not None:
+            raise ValueError(
+                "Tune-sklearn no longer supports nested parallelism "
+                "with new versions of joblib/sklearn. Don't set 'sk_n_jobs'.")
         search_optimization = search_optimization.lower()
         available_optimizations = [
             "random",

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -169,9 +169,6 @@ class TuneSearchCV(TuneBaseSearchCV):
             will be run using Ray's 'local mode'. This can
             lead to significant speedups if the model takes < 10 seconds
             to fit due to removing inter-process communication overheads.
-        sk_n_jobs (int): Number of jobs to run in parallel for cross validating
-            each hyperparameter set; the ``n_jobs`` parameter for
-            ``cross_validate`` call to sklearn when early stopping isn't used.
         refit (bool, str, or `callable`): Refit an estimator using the
             best found parameters on the whole dataset.
             For multiple metric evaluation, this needs to be a string denoting
@@ -285,7 +282,6 @@ class TuneSearchCV(TuneBaseSearchCV):
                  n_trials=10,
                  scoring=None,
                  n_jobs=None,
-                 sk_n_jobs=-1,
                  refit=True,
                  cv=None,
                  verbose=0,
@@ -358,7 +354,6 @@ class TuneSearchCV(TuneBaseSearchCV):
             early_stopping=early_stopping,
             scoring=scoring,
             n_jobs=n_jobs or -1,
-            sk_n_jobs=sk_n_jobs,
             cv=cv,
             verbose=verbose,
             refit=refit,


### PR DESCRIPTION
It seems like in newer versions of sklearn, we are unable to use joblib inside Ray.

This change makes it so that users will avoid errors in the future.

Closes https://github.com/ray-project/tune-sklearn/issues/135