### PR TITLE
Add tests for `points_to_evaluate`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -U pytest
         python -m pip install codecov
-        python -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+        python -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.2.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
         python -m pip install -U -q scikit-learn scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna keras
         if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
     - name: Install package

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ matrix:
     - os: linux
       python: 3.6
       env: PYTHON=3.6 OS=LINUX SKLEARN_N_JOBS=1 RAY_MASTER=1
-      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
-    - os: linux
-      python: 3.7
-      env: PYTHON=3.7 OS=LINUX SKLEARN_N_JOBS=1 RAY_MASTER=1
-      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+      before_script: pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.2.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.2
       language: generic
       env: PYTHON=3.6 PYTHONWARNINGS=ignore OS=MAC SKLEARN_N_JOBS=1
       before_script: pip install -U ray
@@ -41,15 +37,6 @@ matrix:
     - os: linux
       python: 3.6
       env: PYTHON=3.6 OS=LINUX SKLEARN_N_JOBS=1 FAST=1
-      before_script: pip install -U ray
-      script:
-        - if [ "$OS" == "MAC" ]; then brew install -q libomp > /dev/null ; fi
-        - pip3 install -e .
-        - cd examples
-        - for f in *.py; do echo "running $f" && python3 "$f" || exit 1 ; done
-    - os: linux
-      python: 3.7
-      env: PYTHON=3.7 OS=LINUX SKLEARN_N_JOBS=1 FAST=1
       before_script: pip install -U ray
       script:
         - if [ "$OS" == "MAC" ]; then brew install -q libomp > /dev/null ; fi


### PR DESCRIPTION
This Ray PR adds `points_to_evaluate` for all search algorithms (except random search): https://github.com/ray-project/ray/pull/12790

This PR here adds tests for this in tune-sklearn. Points that should be evaluated first can be passed via the `search_kwargs` argument. E.g.:

```
        points = [{
            "alpha": 0.4,
            "epsilon": 0.01,
            "penalty": "elasticnet"
        }, {
            "alpha": 0.3,
            "epsilon": 0.02,
            "penalty": "l1"
        }]

        tune_search = TuneSearchCV(
            self.clf,
            self.parameter_grid,
            search_optimization=search_method,
            cv=2,
            n_trials=3,
            n_jobs=1,
            refit=True,
            points_to_evaluate=points)
```

Closes #73 

