### PR TITLE
Fix pipeline_auto_early_stop

### DIFF
--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -481,7 +481,7 @@ class RandomizedSearchTest(unittest.TestCase):
         from xgboost.sklearn import XGBClassifier
         from sklearn.pipeline import Pipeline
         TuneSearchCV(
-            Pipeline([('model', XGBClassifier())]), {"model__C": [1, 2]},
+            Pipeline([("model", XGBClassifier())]), {"model__C": [1, 2]},
             early_stopping=True,
             pipeline_auto_early_stop=True,
             cv=2,
@@ -494,7 +494,7 @@ class RandomizedSearchTest(unittest.TestCase):
         from lightgbm import LGBMClassifier
         from sklearn.pipeline import Pipeline
         TuneSearchCV(
-            Pipeline([('model', LGBMClassifier())]),
+            Pipeline([("model", LGBMClassifier())]),
             {"model__learning_rate": [0.1, 0.5]},
             early_stopping=True,
             pipeline_auto_early_stop=True,
@@ -507,7 +507,7 @@ class RandomizedSearchTest(unittest.TestCase):
         from catboost import CatBoostClassifier
         from sklearn.pipeline import Pipeline
         TuneSearchCV(
-            Pipeline([('model', CatBoostClassifier())]),
+            Pipeline([("model", CatBoostClassifier())]),
             {"model__learning_rate": [0.1, 0.5]},
             early_stopping=True,
             pipeline_auto_early_stop=True,

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -476,6 +476,45 @@ class RandomizedSearchTest(unittest.TestCase):
             pipe, parameter_grid, early_stopping=True, max_iters=10)
         tune_search.fit(x, y)
 
+    @unittest.skipIf(not has_xgboost(), "xgboost not installed")
+    def test_early_stop_xgboost_pipeline(self):
+        from xgboost.sklearn import XGBClassifier
+        from sklearn.pipeline import Pipeline
+        TuneSearchCV(
+            Pipeline([('model', XGBClassifier())]), {"model__C": [1, 2]},
+            early_stopping=True,
+            pipeline_auto_early_stop=True,
+            cv=2,
+            n_trials=2,
+            max_iters=10)
+
+    @unittest.skipIf(not has_required_lightgbm_version(),
+                     "lightgbm not installed")
+    def test_early_stop_lightgbm_pipeline(self):
+        from lightgbm import LGBMClassifier
+        from sklearn.pipeline import Pipeline
+        TuneSearchCV(
+            Pipeline([('model', LGBMClassifier())]),
+            {"model__learning_rate": [0.1, 0.5]},
+            early_stopping=True,
+            pipeline_auto_early_stop=True,
+            cv=2,
+            n_trials=2,
+            max_iters=10)
+
+    @unittest.skipIf(not has_catboost(), "catboost not installed")
+    def test_early_stop_catboost_pipeline(self):
+        from catboost import CatBoostClassifier
+        from sklearn.pipeline import Pipeline
+        TuneSearchCV(
+            Pipeline([('model', CatBoostClassifier())]),
+            {"model__learning_rate": [0.1, 0.5]},
+            early_stopping=True,
+            pipeline_auto_early_stop=True,
+            cv=2,
+            n_trials=2,
+            max_iters=10)
+
     def test_max_iters(self):
         X, y = make_classification(
             n_samples=50, n_features=50, n_informative=3, random_state=0)

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -404,7 +404,7 @@ class _PipelineTrainable(_Trainable):
         estimator.fit(
             X_train, y_train,
             **{f"{self.base_estimator_name}__xgb_model": self.saved_models[i]})
-        self.saved_models[i] = estimator.get_booster()
+        self.saved_models[i] = estimator.steps[-1][1].get_booster()
 
     def _early_stopping_lgbm(self, i, estimator, X_train, y_train):
         """Handles early stopping on LightGBM estimators.
@@ -414,7 +414,7 @@ class _PipelineTrainable(_Trainable):
             X_train, y_train, **{
                 f"{self.base_estimator_name}__init_model": self.saved_models[i]
             })
-        self.saved_models[i] = estimator.booster_
+        self.saved_models[i] = estimator.steps[-1][1].booster_
 
     def _early_stopping_catboost(self, i, estimator, X_train, y_train):
         """Handles early stopping on CatBoost estimators.
@@ -424,7 +424,7 @@ class _PipelineTrainable(_Trainable):
             X_train, y_train, **{
                 f"{self.base_estimator_name}__init_model": self.saved_models[i]
             })
-        self.saved_models[i] = estimator
+        self.saved_models[i] = estimator.steps[-1][1]
 
     def _early_stopping_ensemble(self, i, estimator, X_train, y_train):
         """Handles early stopping on ensemble estimators.


### PR DESCRIPTION
An oversight in `_PipelineTrainable` caused the xgboost/lightgbm/catboost methods to try and get boosters from the Pipeline object instead of the actual estimator, causing an exception. This PR fixes that and adds unit tests to check for this in the future.