### PR TITLE
Positional arg to keyword in pipeline partial fit

### DIFF
--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -378,7 +378,7 @@ class _PipelineTrainable(_Trainable):
 
         """
         if hasattr(estimator, "partial_fit"):
-            estimator.partial_fit(X_train, y_train, np.unique(self.y))
+            estimator.partial_fit(X_train, y_train, classes=np.unique(self.y))
         else:
             # Workaround if the pipeline itself doesn't support partial_fit
             # (default sklearn doesn't). We set the final step to


### PR DESCRIPTION
Fixes a PyCaret issue. It should have been like this from the start, as it is much more robust in general.