### PR TITLE
Update code snippets in README to showcase ray.tune SearchSpaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ notifications:
 
 install:
   - pip3 install -U -q pip
-  - pip3 install -U -q scikit-optimize==0.8.1 hyperopt==0.2.5 hpbandster==0.7.4 ConfigSpace==0.4.10 scipy dataclasses optuna==2.3.0
+  - pip3 install -U -q scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna==2.3.0
   - pip3 install -q -r requirements-test.txt
   - pip3 install --upgrade -q keras
   - pip3 install -U -q scikit-learn pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ notifications:
 
 install:
   - pip3 install -U -q pip
-  - pip3 install -U -q scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna
+  - pip3 install -U -q scikit-optimize==0.8.1 hyperopt==0.2.5 hpbandster==0.7.4 ConfigSpace==0.4.10 scipy dataclasses optuna==2.3.0
   - pip3 install -q -r requirements-test.txt
   - pip3 install --upgrade -q keras
   - pip3 install -U -q scikit-learn pytest

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ It also provides a wrapper for several search optimization algorithms from Ray T
 
 All algorithms other than RandomListSearcher accept parameter distributions in the form of dictionaries in the format `{ param_name: str : distribution: tuple or list }`.
 
-Tuples represent real distributions and should be two-element or three-element, in the format `(lower_bound: float, upper_bound: float, Optional: "uniform" (default) or "log-uniform")`. Lists represent categorical distributions. [Ray Tune Search Spaces](https://docs.ray.io/en/master/tune/api_docs/search_space.html) are also supported. Furthermore, each algorithm also accepts parameters in their own specific format. More information in [Tune documentation](https://docs.ray.io/en/master/tune/api_docs/suggestion.html).
+Tuples represent real distributions and should be two-element or three-element, in the format `(lower_bound: float, upper_bound: float, Optional: "uniform" (default) or "log-uniform")`. Lists represent categorical distributions. [Ray Tune Search Spaces](https://docs.ray.io/en/master/tune/api_docs/search_space.html) are also supported and provide a rich set of potential distributions. Search spaces allow for users to specify complex, potentially nested search spaces and parameter distributions. Furthermore, each algorithm also accepts parameters in their own specific format. More information in [Tune documentation](https://docs.ray.io/en/master/tune/api_docs/suggestion.html).
 
 Random Search (default) accepts dictionaries in the format `{ param_name: str : distribution: list }` or a list of such dictionaries, just like scikit-learn's `RandomizedSearchCV`.
 
@@ -135,6 +135,7 @@ from tune_sklearn import TuneSearchCV
 
 # Other imports
 import scipy
+from ray import tune
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import SGDClassifier
@@ -146,7 +147,8 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=1000)
 # Example parameter distributions to tune from SGDClassifier
 # Note the use of tuples instead if non-random optimization is desired
 param_dists = {
-    'alpha': (1e-4, 1e-1),
+    'loss': ['squared_hinge', 'hinge'], 
+    'alpha': (1e-4, 1e-1, 'log-uniform'),
     'epsilon': (1e-2, 1e-1)
 }
 
@@ -158,6 +160,17 @@ bohb_tune_search = TuneSearchCV(SGDClassifier(),
 )
 
 bohb_tune_search.fit(X_train, y_train)
+
+# Define the `param_dists using the SearchSpace API
+# This allows the specification of sampling from discrete and 
+# categorical distributions (below for the `learning_rate` scheduler parameter)
+param_dists = {
+    'loss': tune.choice(['squared_hinge', 'hinge']),
+    'alpha': tune.loguniform(1e-4, 1e-1),
+    'epsilon': tune.uniform(1e-2, 1e-1),
+    'learning_rate': tune.sample_from(lambda _: np.random.choice(['constant', 'optimal'], p=[0.2, 0.8])),
+}
+
 
 hyperopt_tune_search = TuneSearchCV(SGDClassifier(),
     param_distributions=param_dists,

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ param_dists = {
     'loss': tune.choice(['squared_hinge', 'hinge']),
     'alpha': tune.loguniform(1e-4, 1e-1),
     'epsilon': tune.uniform(1e-2, 1e-1),
-    'learning_rate': tune.sample_from(lambda _: np.random.choice(['constant', 'optimal'], p=[0.2, 0.8])),
 }
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ tabulate
 ray[tune]
 scikit-optimize>=0.8.1
 parameterized
-pytest
+pytest>=6.1.2
 xgboost
 torch
 torchvision


### PR DESCRIPTION
Small PR to update the example code snippets in the README to illustrate how users can leverage SearchSpaces to define param distributions in `TuneSearchCV`.
- Update definition of parameter distributions to illustrate new
ways of specifying parameter distributions with SearchSpaces.
- Illustrates ways to sample over discrete distributions in a couple of ways