### PR TITLE
Pass estimators via object store IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ notifications:
 
 install:
   - pip3 install -U -q pip
-  - pip3 install -U -q scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna==2.3.0
+  - pip3 install -U -q scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna==2.5.0
   - pip3 install -q -r requirements-test.txt
   - pip3 install --upgrade -q keras
   - pip3 install -U -q scikit-learn pytest

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -1,6 +1,5 @@
 """ Helper class to train models using Ray backend
 """
-from sklearn.base import clone
 from sklearn.model_selection import cross_validate
 from sklearn.utils.metaestimators import _safe_split
 import numpy as np
@@ -43,7 +42,8 @@ class _Trainable(Trainable):
                 stopping if it is set to true.
 
         """
-        self.estimator_list = clone(config.pop("estimator_list"))
+        estimator_ids = list(config.pop("estimator_ids"))
+        self.estimator_list = ray.get(estimator_ids)
         self.early_stopping = config.pop("early_stopping")
         self.early_stop_type = config.pop("early_stop_type")
         X_id = config.pop("X_id")

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -754,7 +754,7 @@ class TuneBaseSearchCV(BaseSearchCV):
                 and the values are the numeric values set to those variables.
         """
         for key in [
-                "estimator_list", "early_stopping", "X_id", "y_id", "groups",
+                "estimator_ids", "early_stopping", "X_id", "y_id", "groups",
                 "cv", "fit_params", "scoring", "max_iters",
                 "return_train_score", "n_jobs", "metric_name",
                 "early_stop_type"

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -4,8 +4,8 @@
 import warnings
 import os
 
+import ray
 from ray.tune.stopper import CombinedStopper
-from sklearn.base import clone
 from sklearn.model_selection import ParameterGrid
 from ray import tune
 from tune_sklearn.list_searcher import ListSearcher
@@ -239,11 +239,11 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             trainable = _PipelineTrainable
 
         if self.early_stopping is not None:
-            config["estimator_list"] = [
-                clone(self.estimator) for _ in range(self.n_splits)
+            config["estimator_ids"] = [
+                ray.put(self.estimator) for _ in range(self.n_splits)
             ]
         else:
-            config["estimator_list"] = [self.estimator]
+            config["estimator_ids"] = [ray.put(self.estimator)]
 
         stopper = MaximumIterationStopper(max_iter=self.max_iters)
         if self.stopper:


### PR DESCRIPTION
Currently estimator objects are passed via the `config` parameter (as is the data). However, in some cases this can lead to unexpected errors when creating the search space with Hyperopt.

By passing the estimators via the object store we circumvent this problem.

After the next release we might want to use `tune.with_parameters()` to avoid passing anything other than the search space via the config parameter, see https://github.com/ray-project/ray/pull/14532

Closes #https://github.com/ray-project/tune-sklearn/issues/186