### PR TITLE
Allow any searcher, fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         python -m pip install -U pytest
         python -m pip install codecov
         python -m pip install -U ray
-        python -m pip install -U -q scikit-learn scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna==2.3.0 keras
+        python -m pip install -U -q scikit-learn scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna keras
         if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
     - name: Install package
       run: |

--- a/examples/custom_searcher_example.py
+++ b/examples/custom_searcher_example.py
@@ -1,0 +1,42 @@
+"""
+An example using a Searcher (HEBOSearch) not defined
+directly in TuneSearchCV.
+"""
+
+from tune_sklearn import TuneSearchCV
+from ray import tune
+from ray.tune.suggest.hebo import HEBOSearch
+from sklearn.ensemble import RandomForestClassifier
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+digits = datasets.load_digits()
+x = digits.data
+y = digits.target
+x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=.2)
+
+clf = RandomForestClassifier()
+param_distributions = {
+    "n_estimators": tune.randint(20, 80),
+    "max_depth": tune.randint(2, 10)
+}
+
+# If a Searcher is initialized without specifying search space,
+# it will use the space passed to TuneSearchCV
+# (in this example: param_distributions)
+searcher = HEBOSearch()
+
+# It is also possible to use user-defined Searchers, as long as
+# they inherit from ray.tune.suggest.Searcher and have the following
+# attributes: _space, _metric, _mode
+
+tune_search = TuneSearchCV(
+    clf, param_distributions, n_trials=3, search_optimization=searcher
+)
+
+tune_search.fit(x_train, y_train)
+
+pred = tune_search.predict(x_test)
+accuracy = np.count_nonzero(np.array(pred) == np.array(y_test)) / len(pred)
+print(accuracy)

--- a/examples/custom_searcher_example.py
+++ b/examples/custom_searcher_example.py
@@ -32,8 +32,7 @@ searcher = HEBOSearch()
 # attributes: _space, _metric, _mode
 
 tune_search = TuneSearchCV(
-    clf, param_distributions, n_trials=3, search_optimization=searcher
-)
+    clf, param_distributions, n_trials=3, search_optimization=searcher)
 
 tune_search.fit(x_train, y_train)
 

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -9,5 +9,6 @@ builtin cd "$ROOT/examples"
 PYTHON="${PYTHON:-python}"
 # rm catboostclassifier.py
 rm bohb_example.py hpbandster_sgd.py # Temporary hack to avoid breaking CI
+rm custom_searcher_example.py # So we don't need to install HEBO during CI
 for f in *.py; do echo "running $f" && $PYTHON "$f" || exit 1 ; done
 

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -574,7 +574,7 @@ class GridSearchTest(unittest.TestCase):
             scoring=("accuracy", "f1_micro"),
             max_iters=20,
             cv=2,
-            refit=False)
+            refit="accuracy")
         tune_search.fit(X, y)
         self.assertTrue(tune_search.multimetric_)
 
@@ -608,7 +608,7 @@ class GridSearchTest(unittest.TestCase):
             parameter_grid,
             scoring=scoring,
             max_iters=20,
-            refit=False,
+            refit="accuracy",
             cv=cv)
         tune_search.fit(X, y)
         result = tune_search.cv_results_

--- a/tests/test_randomizedsearch.py
+++ b/tests/test_randomizedsearch.py
@@ -590,6 +590,26 @@ class RandomizedSearchTest(unittest.TestCase):
         # finish. Allow for some initialization overhead
         self.assertLess(taken, 25.0)
 
+    def test_wrong_mode(self):
+        model = SGDClassifier()
+
+        parameter_grid = {"alpha": [1e-4, 1e-1, 1], "epsilon": [0.01, 0.1]}
+
+        TuneSearchCV(
+            model, parameter_grid, search_optimization="random", mode="min")
+
+        TuneSearchCV(
+            model, parameter_grid, search_optimization="random", mode="max")
+
+        with self.assertRaises(AssertionError) as exc:
+            TuneSearchCV(
+                model,
+                parameter_grid,
+                search_optimization="random",
+                mode="this_is_an_invalid_mode")
+        self.assertTrue((
+            "`mode` must be 'min' or 'max'") in str(exc.exception))
+
 
 class TestSearchSpace(unittest.TestCase):
     def setUp(self):

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -561,6 +561,13 @@ class TuneBaseSearchCV(BaseSearchCV):
         metric = self._metric_name
         base_metric = self._base_metric_name
 
+        if f"rank_test_{base_metric}" not in self.cv_results_ and self.refit:
+            warnings.warn(
+                "Cannot refit estimator due to required data being missing "
+                "(probably due to trials not completing). `best_estimator` "
+                "will not be set.", UserWarning)
+            return self
+
         # For multi-metric evaluation, store the best_index, best_params and
         # best_score iff refit is one of the scorer names
         # In single metric evaluation, refit_metric is "score"
@@ -575,10 +582,10 @@ class TuneBaseSearchCV(BaseSearchCV):
                         or self.best_index >= len(self.cv_results_["params"])):
                     raise IndexError("best_index index out of range")
             else:
-                self.best_index = self.cv_results_["rank_test_%s" %
-                                                   base_metric].argmin()
-                self.best_score = self.cv_results_[
-                    "mean_test_%s" % base_metric][self.best_index]
+                self.best_index = self.cv_results_[
+                    f"rank_test_{base_metric}"].argmin()
+                self.best_score = self.cv_results_[f"mean_test_{base_metric}"][
+                    self.best_index]
             best_config = analysis.get_best_config(
                 metric=metric, mode="max", scope="last")
             self.best_params = self._clean_config_dict(best_config)

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -44,6 +44,9 @@ from tune_sklearn._detect_booster import is_lightgbm_model
 
 logger = logging.getLogger(__name__)
 
+# sklearn always maximizes
+DEFAULT_MODE = "max"
+
 
 def resolve_early_stopping(early_stopping, max_iters, metric_name):
     if isinstance(early_stopping, str):
@@ -364,7 +367,8 @@ class TuneBaseSearchCV(BaseSearchCV):
                  loggers=None,
                  pipeline_auto_early_stop=True,
                  stopper=None,
-                 time_budget_s=None):
+                 time_budget_s=None,
+                 mode=None):
         if max_iters < 1:
             raise ValueError("max_iters must be greater than or equal to 1.")
         self.estimator = estimator
@@ -372,6 +376,10 @@ class TuneBaseSearchCV(BaseSearchCV):
         self.pipeline_auto_early_stop = pipeline_auto_early_stop
         self.stopper = stopper
         self.time_budget_s = time_budget_s
+
+        if mode:
+            assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
+        self.mode = mode or DEFAULT_MODE
 
         if self.pipeline_auto_early_stop and check_is_pipeline(estimator):
             _, self.base_estimator = self.base_estimator.steps[-1]

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -49,27 +49,21 @@ def resolve_early_stopping(early_stopping, max_iters, metric_name):
     if isinstance(early_stopping, str):
         if early_stopping in TuneBaseSearchCV.defined_schedulers:
             if early_stopping == "PopulationBasedTraining":
-                return PopulationBasedTraining(metric=metric_name, mode="max")
+                return PopulationBasedTraining()
             elif early_stopping == "AsyncHyperBandScheduler":
-                return AsyncHyperBandScheduler(
-                    metric=metric_name, mode="max", max_t=max_iters)
+                return AsyncHyperBandScheduler(max_t=max_iters)
             elif early_stopping == "HyperBandScheduler":
-                return HyperBandScheduler(
-                    metric=metric_name, mode="max", max_t=max_iters)
+                return HyperBandScheduler(max_t=max_iters)
             elif early_stopping == "MedianStoppingRule":
-                return MedianStoppingRule(metric=metric_name, mode="max")
+                return MedianStoppingRule()
             elif early_stopping == "ASHAScheduler":
-                return ASHAScheduler(
-                    metric=metric_name, mode="max", max_t=max_iters)
+                return ASHAScheduler(max_t=max_iters)
             elif early_stopping == "HyperBandForBOHB":
-                return HyperBandForBOHB(
-                    metric=metric_name, mode="max", max_t=max_iters)
+                return HyperBandForBOHB(max_t=max_iters)
         raise ValueError("{} is not a defined scheduler. "
                          "Check the list of available schedulers."
                          .format(early_stopping))
     elif isinstance(early_stopping, TrialScheduler):
-        early_stopping._metric = metric_name
-        early_stopping._mode = "max"
         return early_stopping
     else:
         raise TypeError("`early_stopping` must be a str, boolean, "
@@ -511,12 +505,11 @@ class TuneBaseSearchCV(BaseSearchCV):
                 self.estimator, self.scoring)
 
         if self.is_multi:
-            if self.refit and (not isinstance(self.refit, str)
-                               or self.refit not in self.scoring):
+            if not isinstance(self.refit,
+                              str) or self.refit not in self.scoring:
                 raise ValueError("When using multimetric scoring, refit "
                                  "must be the name of the scorer used to "
-                                 "pick the best parameters. If not needed, "
-                                 "set refit to False")
+                                 "pick the best parameters.")
 
         assert isinstance(
             self.n_jobs,

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -139,6 +139,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         time_budget_s (int|float|datetime.timedelta): Global time budget in
             seconds after which all trials are stopped. Can also be a
             ``datetime.timedelta`` object.
+        mode (str): One of {min, max}. Determines whether objective is
+            minimizing or maximizing the metric attribute. Defaults to "max".
     """
 
     def __init__(self,
@@ -159,7 +161,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
                  pipeline_auto_early_stop=True,
                  stopper=None,
                  time_budget_s=None,
-                 sk_n_jobs=None):
+                 sk_n_jobs=None,
+                 mode=None):
         if sk_n_jobs is not None:
             raise ValueError(
                 "Tune-sklearn no longer supports nested parallelism "
@@ -180,7 +183,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             loggers=loggers,
             pipeline_auto_early_stop=pipeline_auto_early_stop,
             stopper=stopper,
-            time_budget_s=time_budget_s)
+            time_budget_s=time_budget_s,
+            mode=mode)
 
         check_error_warm_start(self.early_stop_type, param_grid, estimator)
 
@@ -261,7 +265,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             loggers=self.loggers,
             time_budget_s=self.time_budget_s,
             metric=self._metric_name,
-            mode="max")
+            mode=self.mode)
 
         if isinstance(self.param_grid, list):
             run_args.update(

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -259,7 +259,9 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             resources_per_trial=resources_per_trial,
             local_dir=os.path.expanduser(self.local_dir),
             loggers=self.loggers,
-            time_budget_s=self.time_budget_s)
+            time_budget_s=self.time_budget_s,
+            metric=self._metric_name,
+            mode="max")
 
         if isinstance(self.param_grid, list):
             run_args.update(

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -37,9 +37,6 @@ available_optimizations = {
     OptunaSearch: "optuna",
 }
 
-# sklearn always maximizes
-DEFAULT_MODE = "max"
-
 
 def _check_distribution(dist, search_optimization):
     # Tune Domain is always good
@@ -298,6 +295,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             seconds after which all trials are stopped. Can also be a
             ``datetime.timedelta`` object. The stopping condition is checked
             after receiving a result, i.e. after each training iteration.
+        mode (str): One of {min, max}. Determines whether objective is
+            minimizing or maximizing the metric attribute. Defaults to "max".
         **search_kwargs (Any):
             Additional arguments to pass to the SearchAlgorithms (tune.suggest)
             objects.
@@ -326,6 +325,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                  stopper=None,
                  time_budget_s=None,
                  sk_n_jobs=None,
+                 mode=None,
                  **search_kwargs):
         if sk_n_jobs is not None:
             raise ValueError(
@@ -402,7 +402,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             loggers=loggers,
             pipeline_auto_early_stop=pipeline_auto_early_stop,
             stopper=stopper,
-            time_budget_s=time_budget_s)
+            time_budget_s=time_budget_s,
+            mode=mode)
 
         check_error_warm_start(self.early_stop_type, param_distributions,
                                estimator)
@@ -666,7 +667,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             loggers=self.loggers,
             time_budget_s=self.time_budget_s,
             metric=self._metric_name,
-            mode=DEFAULT_MODE)
+            mode=self.mode)
 
         if self.search_optimization == "random":
             if isinstance(self.param_distributions, list):
@@ -687,13 +688,13 @@ class TuneSearchCV(TuneBaseSearchCV):
                         f"('{self.search_optimization._metric}') "
                         "must match the metric set in TuneSearchCV"
                         f" ('{self._metric_name}')")
-                if self.search_optimization._mode != DEFAULT_MODE:
+                if self.search_optimization._mode != self.mode:
                     raise ValueError(
                         "If a Searcher instance has been initialized with a "
                         "space, its mode "
                         f"('{self.search_optimization._mode}') "
                         "must match the mode set in TuneSearchCV"
-                        f" ('{DEFAULT_MODE}')")
+                        f" ('{self.mode}')")
             elif self._is_param_distributions_all_tune_domains():
                 run_args["config"].update(self.param_distributions)
                 override_search_space = False

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -677,8 +677,17 @@ class TuneSearchCV(TuneBaseSearchCV):
                 search_kwargs["metric"] = run_args.pop("metric")
                 search_kwargs["mode"] = run_args.pop("mode")
                 if run_args["scheduler"]:
-                    run_args["scheduler"]._metric = search_kwargs["metric"]
-                    run_args["scheduler"]._mode = search_kwargs["mode"]
+                    if hasattr(run_args["scheduler"], "_metric") and hasattr(
+                            run_args["scheduler"], "_mode"):
+                        run_args["scheduler"]._metric = search_kwargs["metric"]
+                        run_args["scheduler"]._mode = search_kwargs["mode"]
+                    else:
+                        warnings.warn(
+                            "Could not set `_metric` and `_mode` attributes "
+                            f"on Scheduler {run_args['scheduler']}. "
+                            "This may cause an exception later! "
+                            "Ensure your Scheduler initializes with those "
+                            "attributes.", UserWarning)
 
             if self.search_optimization == "bayesian":
                 if override_search_space:

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -756,10 +756,10 @@ class TuneSearchCV(TuneBaseSearchCV):
                 run_args["search_alg"] = search_algo
 
             else:
+                # This should not happen as we validate the input before
+                # this method. Still, just to be sure, raise an error here.
                 raise ValueError(
-                    "Search optimization must be one of "
-                    f"{', '.join(list(available_optimizations.values()))} "
-                    "or a ray.tune.suggest.Searcher instance.")
+                    f"Invalid search optimizer: {self.search_optimization}")
 
         if isinstance(self.n_jobs, int) and self.n_jobs > 0 \
            and not self._searcher_name == "random":

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -418,7 +418,7 @@ class TuneSearchCV(TuneBaseSearchCV):
         self.search_kwargs = search_kwargs
 
     @property
-    def _str_search_optimization(self):
+    def _searcher_name(self):
         return available_optimizations.get(
             type(self.search_optimization), self.search_optimization)
 
@@ -435,7 +435,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                 configuration for `tune.run`.
 
         """
-        if self._str_search_optimization != "random":
+        if self._searcher_name != "random":
             return
 
         if isinstance(self.param_distributions, list):
@@ -733,7 +733,7 @@ class TuneSearchCV(TuneBaseSearchCV):
                 run_args["search_alg"] = search_algo
 
         if isinstance(self.n_jobs, int) and self.n_jobs > 0 \
-           and not self._str_search_optimization == "random":
+           and not self._searcher_name == "random":
             search_algo = ConcurrencyLimiter(
                 search_algo, max_concurrent=self.n_jobs)
             run_args["search_alg"] = search_algo


### PR DESCRIPTION
This PR:
* Allows the user to pass any Searcher subclass to TuneSearchCV, making it possible to use Searchers other than predefined
* Fixes an issue with multimetric scoring where values for `refit` parameter were not being enforced as intended
* Moves `metric` and `mode` from Searchers/Schedulers to `tune.run` where possible

There are no API breaking changes and CI should pass.

The reason why a Searcher subclass is passed instead of an object is that I can't see a good way of handling various parameters inside it. For example, someone may pass an object with `_metric` and `_mode` already set which would cause issues if those keys were passed to `tune.run` - but it's also not possible to just check for those attributes as there's no requirement of them being there. Forcing the user to pass a class instead (while still allowing them to instantiate it with custom kwargs) seemed like the best solution.