### PR TITLE
Fix detection of BOHB scheduler

### DIFF
--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -733,6 +733,9 @@ class TuneSearchCV(TuneBaseSearchCV):
                     search_space = self._get_bohb_config_space()
                 if self.seed:
                     warnings.warn("'seed' is not implemented for BOHB.")
+                if "max_concurrent" not in search_kwargs and isinstance(
+                        self.n_jobs, int) and self.n_jobs > 0:
+                    search_kwargs["max_concurrent"] = self.n_jobs
                 search_algo = TuneBOHB(space=search_space, **search_kwargs)
                 # search_algo = TuneBOHB(
                 #     space=search_space, seed=self.seed, **search_kwargs)

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -365,13 +365,15 @@ class TuneSearchCV(TuneBaseSearchCV):
 
         can_use_param_distributions = False
 
-        if search_optimization == "bohb":
+        if search_optimization == "bohb" or isinstance(search_optimization,
+                                                       TuneBOHB):
             import ConfigSpace as CS
             can_use_param_distributions = isinstance(check_param_distributions,
                                                      CS.ConfigurationSpace)
-            if early_stopping is False:
-                raise ValueError(
-                    "early_stopping must not be False when using BOHB")
+            if isinstance(early_stopping, bool):
+                if early_stopping is False:
+                    raise ValueError(
+                        "early_stopping must not be False when using BOHB")
             elif not isinstance(early_stopping, HyperBandForBOHB):
                 if early_stopping != "HyperBandForBOHB":
                     warnings.warn("Ignoring early_stopping value, "


### PR DESCRIPTION
Fixes an exception being wrongly raised if a `TuneBOHB` instance is passed directly as a search optimizer. Also sets `max_concurrent` on `TuneBOHB` instance automatically if `"bohb"` is used as the search algorithm.