### PR TITLE
Remove os.path.expanduser (defer to Ray Tune)

### DIFF
--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -2,7 +2,6 @@
     -- Anthony Yu and Michael Chau
 """
 import warnings
-import os
 
 import ray
 from ray.tune.stopper import CombinedStopper

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -268,7 +268,7 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             config=config,
             fail_fast="raise",
             resources_per_trial=resources_per_trial,
-            local_dir=os.path.expanduser(self.local_dir),
+            local_dir=self.local_dir,
             name=self.name,
             loggers=resolve_loggers(self.loggers, self.defined_schedulers),
             time_budget_s=self.time_budget_s,

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -684,7 +684,7 @@ class TuneSearchCV(TuneBaseSearchCV):
             config=config,
             fail_fast="raise",
             resources_per_trial=resources_per_trial,
-            local_dir=os.path.expanduser(self.local_dir),
+            local_dir=self.local_dir,
             name=self.name,
             loggers=resolve_loggers(self.loggers, self.defined_schedulers),
             time_budget_s=self.time_budget_s,

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -8,7 +8,6 @@ import ray
 from ray.tune.stopper import CombinedStopper
 import numpy as np
 import warnings
-import os
 
 from ray import tune
 from ray.tune.sample import Domain


### PR DESCRIPTION
Expanding the path early leads to problems with Ray client. Instead, we should rely on expanding on the Ray Tune side, as this will happen within the remote function call, i.e. on the head node.