### PR TITLE
Support sklearn.compose.TransformedTargetRegressor

### DIFF
--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import Dict
 
+from sklearn.compose import TransformedTargetRegressor
 from sklearn.metrics import check_scoring
 from sklearn.pipeline import Pipeline
 from tune_sklearn._detect_booster import (
@@ -94,6 +95,10 @@ def check_error_warm_start(early_stop_type, estimator_config, estimator):
 
 
 def get_early_stop_type(estimator, early_stopping):
+    # If estimator is TransformedTargetRegressor we should get the wrapped regressor.
+    if isinstance(estimator, TransformedTargetRegressor):
+        estimator = estimator.regressor
+
     if not early_stopping:
         return EarlyStopping.NO_EARLY_STOP
     can_partial_fit = check_partial_fit(estimator)


### PR DESCRIPTION
Currently TuneSearchCV fails when provided with LGBMRegressor provided wrapped inside TransformedTargerRegressor.

For example, this block would fail

```
regressor = LGBMRegressor(**config)

regressor = TransformedTargetRegressorTwo(
    regressor=regressor, func=np.log1p, inverse_func=np.expm1
)
```
Failure happens partly because of failure of tune_search.utils.get_early_stop_type to read the type of the estimator.

Note sure if this is the correct implementation. But it should not break anything.
