### PR TITLE
Move from loggers to logger callbacks

### DIFF
--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -707,6 +707,13 @@ class TuneBaseSearchCV(BaseSearchCV):
                     ". This may cause unexpected issues! If you experience "
                     "issues, please try removing those parameters from "
                     "tune_params.")
+
+            # Merge library-provided and user-provided callbacks
+            library_callbacks = run_args.get("callbacks", None)
+            user_callbacks = tune_params.get("callbacks", None)
+            if library_callbacks and user_callbacks:
+                tune_params["callbacks"] = library_callbacks + user_callbacks
+
             run_args = {**run_args, **tune_params}
         return run_args
 

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -700,7 +700,7 @@ class TuneBaseSearchCV(BaseSearchCV):
 
         if tune_params:
             user_overrides = {k for k in tune_params if k in run_args}
-            user_overrides.pop("callbacks", None)
+            user_overrides.discard("callbacks")
             if user_overrides:
                 warnings.warn(
                     "The following preset tune.run parameters will "
@@ -714,7 +714,8 @@ class TuneBaseSearchCV(BaseSearchCV):
             user_callbacks = tune_params.get("callbacks", None)
             if library_callbacks and user_callbacks:
                 tune_params["callbacks"] = library_callbacks + user_callbacks
-                logger.info("Merging default and user provided tune callbacks.")
+                logger.info(
+                    "Merging default and user provided tune callbacks.")
 
             run_args = {**run_args, **tune_params}
         return run_args

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -700,6 +700,7 @@ class TuneBaseSearchCV(BaseSearchCV):
 
         if tune_params:
             user_overrides = {k for k in tune_params if k in run_args}
+            user_overrides.pop("callbacks", None)
             if user_overrides:
                 warnings.warn(
                     "The following preset tune.run parameters will "
@@ -713,6 +714,7 @@ class TuneBaseSearchCV(BaseSearchCV):
             user_callbacks = tune_params.get("callbacks", None)
             if library_callbacks and user_callbacks:
                 tune_params["callbacks"] = library_callbacks + user_callbacks
+                logger.info("Merging default and user provided tune callbacks.")
 
             run_args = {**run_args, **tune_params}
         return run_args

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -13,7 +13,7 @@ from tune_sklearn.list_searcher import ListSearcher
 from tune_sklearn.utils import (_check_param_grid_tune_grid_search,
                                 check_is_pipeline, check_error_warm_start,
                                 is_tune_grid_search, MaximumIterationStopper,
-                                resolve_loggers)
+                                resolve_logger_callbacks)
 from tune_sklearn.tune_basesearch import TuneBaseSearchCV
 from tune_sklearn._trainable import _Trainable
 from tune_sklearn._trainable import _PipelineTrainable
@@ -277,7 +277,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             resources_per_trial=resources_per_trial,
             local_dir=self.local_dir,
             name=self.name,
-            loggers=resolve_loggers(self.loggers, self.defined_schedulers),
+            callbacks=resolve_logger_callbacks(self.loggers,
+                                               self.defined_loggers),
             time_budget_s=self.time_budget_s,
             metric=self._metric_name,
             mode=self.mode)

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -23,7 +23,7 @@ from tune_sklearn.utils import check_is_pipeline, MaximumIterationStopper
 from tune_sklearn.tune_basesearch import TuneBaseSearchCV
 from tune_sklearn._trainable import _Trainable, _PipelineTrainable
 from tune_sklearn.list_searcher import RandomListSearcher
-from tune_sklearn.utils import check_error_warm_start, resolve_loggers
+from tune_sklearn.utils import check_error_warm_start, resolve_logger_callbacks
 
 logger = logging.getLogger(__name__)
 
@@ -691,7 +691,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             resources_per_trial=resources_per_trial,
             local_dir=self.local_dir,
             name=self.name,
-            loggers=resolve_loggers(self.loggers, self.defined_schedulers),
+            callbacks=resolve_logger_callbacks(self.loggers,
+                                               self.defined_loggers),
             time_budget_s=self.time_budget_s,
             metric=self._metric_name,
             mode=self.mode)

--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -271,7 +271,7 @@ def _check_param_grid_tune_grid_search(param_grid):
 
 
 def resolve_logger_callbacks(loggers, defined_loggers) -> List[Callback]:
-    init_loggers = {JsonLoggerCallback, CSVLoggerCallback}
+    init_loggers = {JsonLoggerCallback(), CSVLoggerCallback()}
     if loggers is None:
         return list(init_loggers)
 

--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -282,18 +282,20 @@ def resolve_logger_callbacks(loggers, defined_loggers) -> List[Callback]:
     for log in loggers:
         if isinstance(log, str):
             if log == "tensorboard":
-                init_loggers.add(TBXLoggerCallback)
+                init_loggers.add(TBXLoggerCallback())
             elif log == "csv":
-                init_loggers.add(CSVLoggerCallback)
+                init_loggers.add(CSVLoggerCallback())
             elif log == "mlflow":
-                init_loggers.add(MLflowLoggerCallback)
+                init_loggers.add(MLflowLoggerCallback())
             elif log == "json":
-                init_loggers.add(JsonLoggerCallback)
+                init_loggers.add(JsonLoggerCallback())
             else:
                 raise ValueError(f"{log} is not one of the defined loggers: "
                                  f"{defined_loggers}")
-        elif inspect.isclass(log) and issubclass(log, LoggerCallback):
+        elif isinstance(log, LoggerCallback):
             init_loggers.add(log)
+        elif inspect.isclass(log) and issubclass(log, LoggerCallback):
+            init_loggers.add(log())
         elif inspect.isclass(log) and issubclass(log, Logger):
             warnings.warn(
                 "Passing `Logger`s is deprecated - please use "


### PR DESCRIPTION
`loggers` have been deprecated for some time - use `callbacks` instead

Closes https://github.com/ray-project/tune-sklearn/issues/239