### PR TITLE
add license metadata to package setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     description=("A drop-in replacement for Scikit-Learn's "
                  "GridSearchCV / RandomizedSearchCV with cutting edge "
                  "hyperparameter tuning techniques."),
+    license="Apache 2.0",
     long_description=io.open(
         os.path.join(ROOT_DIR, "README.md"), "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
add license metadata to package setup definition

package scanning system prevents install of packages with missing license metadata. Unable to test this package.