### PR TITLE
Don't store `fit_params`, use `with_parameters` for it

### DIFF
--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -44,6 +44,7 @@ class TrainableTest(unittest.TestCase):
             n_samples=50, n_features=50, n_informative=3, random_state=0)
         cls.y = y
         cls.X = X
+        cls.fit_params = None
 
     @classmethod
     def tearDownClass(cls):
@@ -59,7 +60,6 @@ class TrainableTest(unittest.TestCase):
         config["max_iters"] = 1
         config["groups"] = None
         config["cv"] = cv
-        config["fit_params"] = None
         config["scoring"], _ = _check_multimetric_scoring(
             estimator_list[0], scoring=None)
         config["return_train_score"] = False

--- a/tune_sklearn/_trainable.py
+++ b/tune_sklearn/_trainable.py
@@ -27,11 +27,17 @@ class _Trainable(Trainable):
     def main_estimator(self):
         return self.estimator_list[0]
 
-    def setup(self, config, X=None, y=None, estimator_list=None):
+    def setup(self,
+              config,
+              X=None,
+              y=None,
+              estimator_list=None,
+              fit_params=None):
         # forward-compatbility
         self.X = X
         self.y = y
         self.original_estimator_list = estimator_list
+        self.fit_params = fit_params
         self._setup(config)
 
     def _setup(self, config):
@@ -48,7 +54,6 @@ class _Trainable(Trainable):
         self.early_stopping = config.pop("early_stopping")
         self.early_stop_type = config.pop("early_stop_type")
         self.groups = config.pop("groups")
-        self.fit_params = config.pop("fit_params")
         self.scoring = config.pop("scoring")
         self.max_iters = config.pop("max_iters")
         self.cv = config.pop("cv")

--- a/tune_sklearn/tune_basesearch.py
+++ b/tune_sklearn/tune_basesearch.py
@@ -522,7 +522,6 @@ class TuneBaseSearchCV(BaseSearchCV):
         config["early_stop_type"] = self.early_stop_type
         config["groups"] = groups
         config["cv"] = cv
-        config["fit_params"] = fit_params
         config["scoring"] = self.scoring_
         config["max_iters"] = self.max_iters
         config["return_train_score"] = self.return_train_score
@@ -531,7 +530,7 @@ class TuneBaseSearchCV(BaseSearchCV):
 
         self._fill_config_hyperparam(config)
         self.analysis_ = self._tune_run(X, y, config, resources_per_trial,
-                                        tune_params)
+                                        tune_params, fit_params)
 
         self.cv_results_ = self._format_results(self.n_splits, self.analysis_)
 
@@ -674,7 +673,13 @@ class TuneBaseSearchCV(BaseSearchCV):
         """
         raise NotImplementedError("Define in child class")
 
-    def _tune_run(self, X, y, config, resources_per_trial, tune_params=None):
+    def _tune_run(self,
+                  X,
+                  y,
+                  config,
+                  resources_per_trial,
+                  tune_params=None,
+                  fit_params=None):
         """Wrapper to call ``tune.run``. Implement this in a child class.
 
         Args:
@@ -691,6 +696,8 @@ class TuneBaseSearchCV(BaseSearchCV):
             tune_params (dict): User defined parameters passed to
                 ``tune.run``. Parameters inside `tune_params` override
                 preset parameters.
+            fit_params (dict): Parameters passed to the ``fit`` method
+                of the estimator.
 
         """
         raise NotImplementedError("Define in child class")
@@ -737,8 +744,8 @@ class TuneBaseSearchCV(BaseSearchCV):
                 and the values are the numeric values set to those variables.
         """
         for key in [
-                "early_stopping", "groups", "cv", "fit_params", "scoring",
-                "max_iters", "return_train_score", "n_jobs", "metric_name",
+                "early_stopping", "groups", "cv", "scoring", "max_iters",
+                "return_train_score", "n_jobs", "metric_name",
                 "early_stop_type"
         ]:
             config.pop(key, None)

--- a/tune_sklearn/tune_gridsearch.py
+++ b/tune_sklearn/tune_gridsearch.py
@@ -225,7 +225,13 @@ class TuneGridSearchCV(TuneBaseSearchCV):
         """
         return len(list(ParameterGrid(self.param_grid)))
 
-    def _tune_run(self, X, y, config, resources_per_trial, tune_params=None):
+    def _tune_run(self,
+                  X,
+                  y,
+                  config,
+                  resources_per_trial,
+                  tune_params=None,
+                  fit_params=None):
         """Wrapper to call ``tune.run``. Multiple estimators are generated when
         early stopping is possible, whereas a single estimator is
         generated when  early stopping is not possible.
@@ -245,6 +251,8 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             tune_params (dict): User defined parameters passed to
                 ``tune.run``. Parameters inside `tune_params` override
                 preset parameters.
+            fit_params (dict): Parameters passed to the ``fit`` method
+                of the estimator.
 
         Returns:
             analysis (`ExperimentAnalysis`): Object returned by
@@ -293,7 +301,11 @@ class TuneGridSearchCV(TuneBaseSearchCV):
             run_args, tune_params)
 
         trainable = tune.with_parameters(
-            trainable, X=X, y=y, estimator_list=estimator_list)
+            trainable,
+            X=X,
+            y=y,
+            estimator_list=estimator_list,
+            fit_params=fit_params)
 
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/tune_sklearn/tune_search.py
+++ b/tune_sklearn/tune_search.py
@@ -630,7 +630,13 @@ class TuneSearchCV(TuneBaseSearchCV):
                 raise ImportError("It appears that optuna is not installed. "
                                   "Do: pip install optuna") from None
 
-    def _tune_run(self, X, y, config, resources_per_trial, tune_params=None):
+    def _tune_run(self,
+                  X,
+                  y,
+                  config,
+                  resources_per_trial,
+                  tune_params=None,
+                  fit_params=None):
         """Wrapper to call ``tune.run``. Multiple estimators are generated when
         early stopping is possible, whereas a single estimator is
         generated when early stopping is not possible.
@@ -650,6 +656,8 @@ class TuneSearchCV(TuneBaseSearchCV):
             tune_params (dict): User defined parameters passed to
                 ``tune.run``. Parameters inside `tune_params` override
                 preset parameters.
+            fit_params (dict): Parameters passed to the ``fit`` method
+                of the estimator.
 
         Returns:
             analysis (`ExperimentAnalysis`): Object returned by
@@ -801,7 +809,11 @@ class TuneSearchCV(TuneBaseSearchCV):
             run_args, tune_params)
 
         trainable = tune.with_parameters(
-            trainable, X=X, y=y, estimator_list=estimator_list)
+            trainable,
+            X=X,
+            y=y,
+            estimator_list=estimator_list,
+            fit_params=fit_params)
 
         with warnings.catch_warnings():
             warnings.filterwarnings(


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

Fixes `fit_params` being pickled, causing bloated trial directories.

https://discuss.ray.io/t/no-space-left-on-device-tunesearchcv-disable-saving/7972/