### PR TITLE
Import `mlflow` integration from new `air.integrations` module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -U pytest
         python -m pip install codecov
-        python -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+        python -m pip install -U https://ray-ci-artifact-branch-public.s3.amazonaws.com/0db7f95394de8f63e64b764ab5cea178fe02cc8c/tmp/artifacts/.whl/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
         python -m pip install -U -q scikit-learn scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna keras
         if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
     - name: Install package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -U pytest
         python -m pip install codecov
-        python -m pip install -U https://ray-ci-artifact-branch-public.s3.amazonaws.com/0db7f95394de8f63e64b764ab5cea178fe02cc8c/tmp/artifacts/.whl/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+        python -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
         python -m pip install -U -q scikit-learn scikit-optimize hyperopt hpbandster ConfigSpace scipy dataclasses optuna keras
         if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
     - name: Install package

--- a/tune_sklearn/utils.py
+++ b/tune_sklearn/utils.py
@@ -14,7 +14,7 @@ import inspect
 from ray.tune.logger import (Logger, JsonLoggerCallback, CSVLoggerCallback,
                              TBXLoggerCallback, LegacyLoggerCallback,
                              LoggerCallback)
-from ray.tune.integration.mlflow import MLflowLoggerCallback
+from ray.air.integrations.mlflow import MLflowLoggerCallback
 
 try:
     from ray.tune.stopper import MaximumIterationStopper


### PR DESCRIPTION
Ray has some unit-tests depending on this package. The `ray.tune.integration` package is getting hard-deprecated in Ray 2.6, so this needs package needs to import from the new location at `ray.air.integrations` to unblock that.

In particular, it's this user guide doctest that would fail: https://docs.ray.io/en/latest/tune/examples/tune-sklearn.html